### PR TITLE
sensus 連携: 全 vision フィルタ + payload を FRB 公開 (#9)

### DIFF
--- a/lib/src/rust/api/sensus_bridge.dart
+++ b/lib/src/rust/api/sensus_bridge.dart
@@ -5,52 +5,53 @@
 
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
+part 'sensus_bridge.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `color_matrix_flat`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `eq`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `color_matrix_flat`, `to_sensus`, `to_sensus`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`
 
 /// 指定フィルタの GLSL ES 3.00 ソースを返す。
 ///
 /// **用途**: ビルド時に Flutter アセット（または impeller 変換前の中間 `.frag`）
 /// へ書き出す同期スクリプト用。実機ランタイムでこの文字列を直接 Flutter の
 /// `FragmentProgram` に流し込むことはできない（理由は docs/sensus-integration.md）。
+///
+/// sensus_core の全 vision フィルタに `*_glsl()` getter が存在するため、本関数は
+/// 全 [`VisionFilter`] で非空ソースを返す（shader 非対応フィルタは無い）。
 String visionShaderGlsl({required VisionFilter filter}) =>
     RustLib.instance.api.crateApiSensusBridgeVisionShaderGlsl(filter: filter);
 
 /// 指定フィルタの uniform を、FragmentProgram に `setFloat(i, ..)` する順序の
 /// flat な `Vec<f32>` にして返す。
 ///
-/// `sampler2D uTexture`（= 入力画像）は `setFloat` の対象外なので含めない。
-/// Flutter 側では float uniform を `setFloat(0..)` で順に積み、サンプラは
-/// `setImageSampler(0, ..)` で別途渡す。各インデックスの意味は
-/// [`vision_uniform_layout`] が返すラベルと一致する（同じ順序）。
+/// `sampler2D uTexture`（= 入力画像）および `uMask`（floaters のマスク）は
+/// `setFloat` の対象外なので含めない。Flutter 側では float uniform を `setFloat(0..)`
+/// で順に積み、サンプラは `setImageSampler(..)` で別途渡す。各インデックスの意味は
+/// [`vision_uniform_layout`] が返すラベルと一致する（同じ順序、同じ長さ）。
 ///
 /// # 引数
-/// - `strength`: 0.0..=1.0（範囲外は sensus 側で clamp される）。
-/// - `width` / `height`: 入力画像のピクセルサイズ。解像度依存フィルタ
-///   （Myopia / Photophobia）の半径・texel size 算出に使う。色覚 4 種では未使用。
-/// - `seed`: ランダム系フィルタ用シード。MVP のフィルタでは未使用だが、後続で
-///   Cataract / Floaters 等を足すときに使う（署名を安定させるため今から受ける）。
+/// - `strength`: 0.0..=1.0（範囲外・NaN は sensus 側 `normalize_strength` で clamp / NaN→0）。
+/// - `time`: 秒単位の時間。時間依存フィルタ（Vertigo / BppvRotation）の `uTime` に渡す。
+///   それ以外のフィルタでは無視される（sensus の uniforms getter が time を取らないため）。
+/// - `width` / `height`: 入力画像のピクセルサイズ。解像度依存フィルタの半径・texel size・
+///   resolution・aspect の算出に使う。
 ///
-/// # 各フィルタの返却レイアウト
-/// - Protanopia / Deuteranopia / Tritanopia:
-///   `[uStrength, uMatrix0, uMatrix1, .., uMatrix8]`（計 10 要素）
-/// - Achromatopsia: `[uStrength, uRWeight, uGWeight, uBWeight]`（計 4 要素）
-/// - Myopia: `[uStrength, uRadiusPx, uTexelSizeX, uTexelSizeY]`（計 4 要素）
-/// - Photophobia: `[uRadiusPx, uTexelSizeX, uTexelSizeY]`（計 3 要素。
-///   photophobia.frag は `uStrength` を持たない — strength は半径へ畳み込み済み）
+/// # u32 シード / count / int の扱い
+/// GLSL で `uint`/`int` の uniform（`uSeed`, `uCount`）も f32 に詰める。f32 は 2^24 を
+/// 超える整数を正確に表せないため、seed が巨大だと精度が落ちる（モジュール doc 参照）。
 Float32List visionUniforms(
         {required VisionFilter filter,
         required double strength,
+        required double time,
         required int width,
-        required int height,
-        required BigInt seed}) =>
+        required int height}) =>
     RustLib.instance.api.crateApiSensusBridgeVisionUniforms(
         filter: filter,
         strength: strength,
+        time: time,
         width: width,
-        height: height,
-        seed: seed);
+        height: height);
 
 /// 指定フィルタの uniform レイアウト（各 `setFloat` インデックスのラベル）を返す。
 ///
@@ -61,11 +62,11 @@ List<String> visionUniformLayout({required VisionFilter filter}) =>
     RustLib.instance.api
         .crateApiSensusBridgeVisionUniformLayout(filter: filter);
 
-/// （将来用）sensus-core の CPU `apply` を 1 つだけ薄く公開する。
+/// sensus-core の CPU `apply` を薄く公開する。全 [`VisionFilter`] に対応する
+/// （sensus の `apply` は網羅 match なので payload 付きフィルタも CPU で適用可能）。
 ///
-/// GPU（FragmentProgram）経路が主のため MVP では未使用だが、テストや
-/// GPU 非対応環境のフォールバックに備えて残す。生 RGBA8（`width * height * 4`
-/// バイト）を入力し、同じレイアウトの RGBA8 を返す。
+/// GPU（FragmentProgram）経路が主だが、テストや GPU 非対応環境のフォールバックに使う。
+/// 生 RGBA8（`width * height * 4` バイト）を入力し、同じレイアウトの RGBA8 を返す。
 ///
 /// 注意: これは sensus の `image::DynamicImage` 経路を通すため GPU 経路より遅い。
 /// 大きな画像をリアルタイム処理する用途には使わないこと。
@@ -82,31 +83,153 @@ Uint8List applyVisionCpuRgba8(
         height: height,
         strength: strength);
 
-/// Dart 側で扱う vision フィルタ（MVP サブセット）。
-///
-/// sensus_core::Filter のうち、本 Issue (#7, sensus 連携 1/3) でブリッジを
-/// 通すものだけを列挙する。MVP は色覚 4 種 + 解像度依存の 2 例。全フィルタ網羅は
-/// 後続フェーズで `sensus_core::Filter` 全バリアントへ拡張する。
-///
-/// パラメータは MVP では `strength` 中心とし、解像度依存フィルタは
-/// [`vision_uniforms`] へ `width`/`height` を、ランダム系は `seed` を渡す。
-enum VisionFilter {
+@freezed
+sealed class VisionFilter with _$VisionFilter {
+  const VisionFilter._();
+
   /// 1型2色覚（赤）。uniform: uStrength + uMatrix[9]。
-  protanopia,
+  const factory VisionFilter.protanopia() = VisionFilter_Protanopia;
 
   /// 2型2色覚（緑）。uniform: uStrength + uMatrix[9]。
-  deuteranopia,
+  const factory VisionFilter.deuteranopia() = VisionFilter_Deuteranopia;
 
   /// 3型2色覚（青黄）。uniform: uStrength + uMatrix[9]。
-  tritanopia,
+  const factory VisionFilter.tritanopia() = VisionFilter_Tritanopia;
 
   /// 全色盲。uniform: uStrength + RGB luma weights。
-  achromatopsia,
+  const factory VisionFilter.achromatopsia() = VisionFilter_Achromatopsia;
 
-  /// 近視（解像度依存の disk blur）。uniform: uStrength + uRadiusPx + uTexelSize。
-  myopia,
+  /// 四色型色覚。uniform: uStrength。
+  const factory VisionFilter.tetrachromacy() = VisionFilter_Tetrachromacy;
 
-  /// 羞明（解像度依存の bloom）。uniform: uRadiusPx + uTexelSize（uStrength なし）。
-  photophobia,
+  /// 近視（解像度依存の disk blur）。
+  const factory VisionFilter.myopia() = VisionFilter_Myopia;
+
+  /// 遠視（disk blur）。
+  const factory VisionFilter.hyperopia() = VisionFilter_Hyperopia;
+
+  /// 老視（disk blur）。
+  const factory VisionFilter.presbyopia() = VisionFilter_Presbyopia;
+
+  /// 乱視。`axis_deg`: シャープ方向の経線角（度数法、医学慣習）。
+  const factory VisionFilter.astigmatism({
+    required double axisDeg,
+  }) = VisionFilter_Astigmatism;
+
+  /// 緑内障。`mode`: 暗点モード。
+  const factory VisionFilter.glaucoma({
+    required VisionGlaucomaMode mode,
+  }) = VisionFilter_Glaucoma;
+
+  /// 加齢黄斑変性。
+  const factory VisionFilter.macularDegeneration() =
+      VisionFilter_MacularDegeneration;
+
+  /// 半盲。`side`: 0.0 = 左視野消失, 1.0 = 右視野消失。
+  const factory VisionFilter.hemianopia({
+    required double side,
+  }) = VisionFilter_Hemianopia;
+
+  /// 視野狭窄（トンネル視）。
+  const factory VisionFilter.tunnelVision() = VisionFilter_TunnelVision;
+
+  /// 白内障。`seed`: 散乱グレア生成シード。
+  const factory VisionFilter.cataract({
+    required BigInt seed,
+  }) = VisionFilter_Cataract;
+
+  /// 飛蚊症。`seed`/`density`/`size`/`gaze_x`/`gaze_y`。
+  const factory VisionFilter.floaters({
+    required BigInt seed,
+    required double density,
+    required double size,
+    required double gazeX,
+    required double gazeY,
+  }) = VisionFilter_Floaters;
+
+  /// 羞明（解像度依存の bloom）。
+  const factory VisionFilter.photophobia() = VisionFilter_Photophobia;
+
+  /// 夜盲。
+  const factory VisionFilter.nightBlindness() = VisionFilter_NightBlindness;
+
+  /// 浮動性めまい（時間依存）。
+  const factory VisionFilter.vertigo() = VisionFilter_Vertigo;
+
+  /// BPPV 回転性めまい（時間依存）。
+  const factory VisionFilter.bppvRotation() = VisionFilter_BppvRotation;
+
+  /// 前庭神経炎。
+  const factory VisionFilter.vestibularNeuritis() =
+      VisionFilter_VestibularNeuritis;
+
+  /// 複視。`offset_x`/`offset_y`: 幽霊像のずれ（min(W,H) 比のピクセル）, `ghost_strength`: 幽霊像強度。
+  const factory VisionFilter.diplopia({
+    required double offsetX,
+    required double offsetY,
+    required double ghostStrength,
+  }) = VisionFilter_Diplopia;
+
+  /// 眼振。`amplitude`: 振幅（min(W,H) 比）, `direction_deg`: 揺れ方向（度数法）。
+  const factory VisionFilter.nystagmus({
+    required double amplitude,
+    required double directionDeg,
+  }) = VisionFilter_Nystagmus;
+
+  /// 光芒。`num_rays`/`ray_length_ratio`/`threshold`/`dispersion`。
+  const factory VisionFilter.starbursts({
+    required int numRays,
+    required double rayLengthRatio,
+    required double threshold,
+    required double dispersion,
+  }) = VisionFilter_Starbursts;
+
+  /// 眼精疲労。
+  const factory VisionFilter.eyeStrain() = VisionFilter_EyeStrain;
+
+  /// ドライアイ。
+  const factory VisionFilter.dryEye() = VisionFilter_DryEye;
+
+  /// 変視症（歪み）。`freq`: 空間周波数, `seed`: 歪み場シード。
+  const factory VisionFilter.metamorphopsia({
+    required double freq,
+    required BigInt seed,
+  }) = VisionFilter_Metamorphopsia;
+
+  /// コントラスト感度低下。
+  const factory VisionFilter.contrastSensitivity() =
+      VisionFilter_ContrastSensitivity;
+
+  /// ディテールロス（ピクセル化）。`cell_size`: タイルサイズ (px)。
+  const factory VisionFilter.detailLoss({
+    required int cellSize,
+  }) = VisionFilter_DetailLoss;
+
+  /// 閃輝暗点。
+  const factory VisionFilter.teichopsia() = VisionFilter_Teichopsia;
+
+  /// 閃輝（光の星）。`seed`: ランダムシード。
+  const factory VisionFilter.flickeringStars({
+    required BigInt seed,
+  }) = VisionFilter_FlickeringStars;
+}
+
+/// 緑内障の暗点モード。`sensus_core::vision::GlaucomaMode` の FRB 公開ミラー。
+///
+/// FRB は外部クレートの enum を直接 Dart へ出せないため、ue 側で同型を定義して
+/// [`to_sensus`](VisionGlaucomaMode::to_sensus) で変換する。値は
+/// `glaucoma.frag` の `uMode`（0..3）に 1 対 1 対応する。
+enum VisionGlaucomaMode {
+  /// 中心保存 + 周辺 smoothstep vignetting（既定）。uMode=0。
+  vignette,
+
+  /// 上方弧状暗点（Bjerrum 上方）。uMode=1。
+  arcuateSuperior,
+
+  /// 下方弧状暗点（Bjerrum 下方）。uMode=2。
+  arcuateInferior,
+
+  /// 両弧状暗点（進行例）。uMode=3。
+  biarcuate,
   ;
 }

--- a/lib/src/rust/api/sensus_bridge.freezed.dart
+++ b/lib/src/rust/api/sensus_bridge.freezed.dart
@@ -1,0 +1,9872 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sensus_bridge.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$VisionFilter {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $VisionFilterCopyWith<$Res> {
+  factory $VisionFilterCopyWith(
+          VisionFilter value, $Res Function(VisionFilter) then) =
+      _$VisionFilterCopyWithImpl<$Res, VisionFilter>;
+}
+
+/// @nodoc
+class _$VisionFilterCopyWithImpl<$Res, $Val extends VisionFilter>
+    implements $VisionFilterCopyWith<$Res> {
+  _$VisionFilterCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_ProtanopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_ProtanopiaImplCopyWith(
+          _$VisionFilter_ProtanopiaImpl value,
+          $Res Function(_$VisionFilter_ProtanopiaImpl) then) =
+      __$$VisionFilter_ProtanopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_ProtanopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_ProtanopiaImpl>
+    implements _$$VisionFilter_ProtanopiaImplCopyWith<$Res> {
+  __$$VisionFilter_ProtanopiaImplCopyWithImpl(
+      _$VisionFilter_ProtanopiaImpl _value,
+      $Res Function(_$VisionFilter_ProtanopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_ProtanopiaImpl extends VisionFilter_Protanopia {
+  const _$VisionFilter_ProtanopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.protanopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_ProtanopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return protanopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return protanopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (protanopia != null) {
+      return protanopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return protanopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return protanopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (protanopia != null) {
+      return protanopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Protanopia extends VisionFilter {
+  const factory VisionFilter_Protanopia() = _$VisionFilter_ProtanopiaImpl;
+  const VisionFilter_Protanopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_DeuteranopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_DeuteranopiaImplCopyWith(
+          _$VisionFilter_DeuteranopiaImpl value,
+          $Res Function(_$VisionFilter_DeuteranopiaImpl) then) =
+      __$$VisionFilter_DeuteranopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_DeuteranopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_DeuteranopiaImpl>
+    implements _$$VisionFilter_DeuteranopiaImplCopyWith<$Res> {
+  __$$VisionFilter_DeuteranopiaImplCopyWithImpl(
+      _$VisionFilter_DeuteranopiaImpl _value,
+      $Res Function(_$VisionFilter_DeuteranopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_DeuteranopiaImpl extends VisionFilter_Deuteranopia {
+  const _$VisionFilter_DeuteranopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.deuteranopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_DeuteranopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return deuteranopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return deuteranopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (deuteranopia != null) {
+      return deuteranopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return deuteranopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return deuteranopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (deuteranopia != null) {
+      return deuteranopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Deuteranopia extends VisionFilter {
+  const factory VisionFilter_Deuteranopia() = _$VisionFilter_DeuteranopiaImpl;
+  const VisionFilter_Deuteranopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_TritanopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_TritanopiaImplCopyWith(
+          _$VisionFilter_TritanopiaImpl value,
+          $Res Function(_$VisionFilter_TritanopiaImpl) then) =
+      __$$VisionFilter_TritanopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_TritanopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_TritanopiaImpl>
+    implements _$$VisionFilter_TritanopiaImplCopyWith<$Res> {
+  __$$VisionFilter_TritanopiaImplCopyWithImpl(
+      _$VisionFilter_TritanopiaImpl _value,
+      $Res Function(_$VisionFilter_TritanopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_TritanopiaImpl extends VisionFilter_Tritanopia {
+  const _$VisionFilter_TritanopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.tritanopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_TritanopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return tritanopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return tritanopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tritanopia != null) {
+      return tritanopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return tritanopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return tritanopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tritanopia != null) {
+      return tritanopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Tritanopia extends VisionFilter {
+  const factory VisionFilter_Tritanopia() = _$VisionFilter_TritanopiaImpl;
+  const VisionFilter_Tritanopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_AchromatopsiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_AchromatopsiaImplCopyWith(
+          _$VisionFilter_AchromatopsiaImpl value,
+          $Res Function(_$VisionFilter_AchromatopsiaImpl) then) =
+      __$$VisionFilter_AchromatopsiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_AchromatopsiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_AchromatopsiaImpl>
+    implements _$$VisionFilter_AchromatopsiaImplCopyWith<$Res> {
+  __$$VisionFilter_AchromatopsiaImplCopyWithImpl(
+      _$VisionFilter_AchromatopsiaImpl _value,
+      $Res Function(_$VisionFilter_AchromatopsiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_AchromatopsiaImpl extends VisionFilter_Achromatopsia {
+  const _$VisionFilter_AchromatopsiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.achromatopsia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_AchromatopsiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return achromatopsia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return achromatopsia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (achromatopsia != null) {
+      return achromatopsia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return achromatopsia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return achromatopsia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (achromatopsia != null) {
+      return achromatopsia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Achromatopsia extends VisionFilter {
+  const factory VisionFilter_Achromatopsia() = _$VisionFilter_AchromatopsiaImpl;
+  const VisionFilter_Achromatopsia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_TetrachromacyImplCopyWith<$Res> {
+  factory _$$VisionFilter_TetrachromacyImplCopyWith(
+          _$VisionFilter_TetrachromacyImpl value,
+          $Res Function(_$VisionFilter_TetrachromacyImpl) then) =
+      __$$VisionFilter_TetrachromacyImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_TetrachromacyImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_TetrachromacyImpl>
+    implements _$$VisionFilter_TetrachromacyImplCopyWith<$Res> {
+  __$$VisionFilter_TetrachromacyImplCopyWithImpl(
+      _$VisionFilter_TetrachromacyImpl _value,
+      $Res Function(_$VisionFilter_TetrachromacyImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_TetrachromacyImpl extends VisionFilter_Tetrachromacy {
+  const _$VisionFilter_TetrachromacyImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.tetrachromacy()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_TetrachromacyImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return tetrachromacy();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return tetrachromacy?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tetrachromacy != null) {
+      return tetrachromacy();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return tetrachromacy(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return tetrachromacy?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tetrachromacy != null) {
+      return tetrachromacy(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Tetrachromacy extends VisionFilter {
+  const factory VisionFilter_Tetrachromacy() = _$VisionFilter_TetrachromacyImpl;
+  const VisionFilter_Tetrachromacy._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_MyopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_MyopiaImplCopyWith(_$VisionFilter_MyopiaImpl value,
+          $Res Function(_$VisionFilter_MyopiaImpl) then) =
+      __$$VisionFilter_MyopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_MyopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_MyopiaImpl>
+    implements _$$VisionFilter_MyopiaImplCopyWith<$Res> {
+  __$$VisionFilter_MyopiaImplCopyWithImpl(_$VisionFilter_MyopiaImpl _value,
+      $Res Function(_$VisionFilter_MyopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_MyopiaImpl extends VisionFilter_Myopia {
+  const _$VisionFilter_MyopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.myopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_MyopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return myopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return myopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (myopia != null) {
+      return myopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return myopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return myopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (myopia != null) {
+      return myopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Myopia extends VisionFilter {
+  const factory VisionFilter_Myopia() = _$VisionFilter_MyopiaImpl;
+  const VisionFilter_Myopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_HyperopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_HyperopiaImplCopyWith(
+          _$VisionFilter_HyperopiaImpl value,
+          $Res Function(_$VisionFilter_HyperopiaImpl) then) =
+      __$$VisionFilter_HyperopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_HyperopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_HyperopiaImpl>
+    implements _$$VisionFilter_HyperopiaImplCopyWith<$Res> {
+  __$$VisionFilter_HyperopiaImplCopyWithImpl(
+      _$VisionFilter_HyperopiaImpl _value,
+      $Res Function(_$VisionFilter_HyperopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_HyperopiaImpl extends VisionFilter_Hyperopia {
+  const _$VisionFilter_HyperopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.hyperopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_HyperopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return hyperopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return hyperopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (hyperopia != null) {
+      return hyperopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return hyperopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return hyperopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (hyperopia != null) {
+      return hyperopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Hyperopia extends VisionFilter {
+  const factory VisionFilter_Hyperopia() = _$VisionFilter_HyperopiaImpl;
+  const VisionFilter_Hyperopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_PresbyopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_PresbyopiaImplCopyWith(
+          _$VisionFilter_PresbyopiaImpl value,
+          $Res Function(_$VisionFilter_PresbyopiaImpl) then) =
+      __$$VisionFilter_PresbyopiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_PresbyopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_PresbyopiaImpl>
+    implements _$$VisionFilter_PresbyopiaImplCopyWith<$Res> {
+  __$$VisionFilter_PresbyopiaImplCopyWithImpl(
+      _$VisionFilter_PresbyopiaImpl _value,
+      $Res Function(_$VisionFilter_PresbyopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_PresbyopiaImpl extends VisionFilter_Presbyopia {
+  const _$VisionFilter_PresbyopiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.presbyopia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_PresbyopiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return presbyopia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return presbyopia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (presbyopia != null) {
+      return presbyopia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return presbyopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return presbyopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (presbyopia != null) {
+      return presbyopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Presbyopia extends VisionFilter {
+  const factory VisionFilter_Presbyopia() = _$VisionFilter_PresbyopiaImpl;
+  const VisionFilter_Presbyopia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_AstigmatismImplCopyWith<$Res> {
+  factory _$$VisionFilter_AstigmatismImplCopyWith(
+          _$VisionFilter_AstigmatismImpl value,
+          $Res Function(_$VisionFilter_AstigmatismImpl) then) =
+      __$$VisionFilter_AstigmatismImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double axisDeg});
+}
+
+/// @nodoc
+class __$$VisionFilter_AstigmatismImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_AstigmatismImpl>
+    implements _$$VisionFilter_AstigmatismImplCopyWith<$Res> {
+  __$$VisionFilter_AstigmatismImplCopyWithImpl(
+      _$VisionFilter_AstigmatismImpl _value,
+      $Res Function(_$VisionFilter_AstigmatismImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? axisDeg = null,
+  }) {
+    return _then(_$VisionFilter_AstigmatismImpl(
+      axisDeg: null == axisDeg
+          ? _value.axisDeg
+          : axisDeg // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_AstigmatismImpl extends VisionFilter_Astigmatism {
+  const _$VisionFilter_AstigmatismImpl({required this.axisDeg}) : super._();
+
+  @override
+  final double axisDeg;
+
+  @override
+  String toString() {
+    return 'VisionFilter.astigmatism(axisDeg: $axisDeg)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_AstigmatismImpl &&
+            (identical(other.axisDeg, axisDeg) || other.axisDeg == axisDeg));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, axisDeg);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_AstigmatismImplCopyWith<_$VisionFilter_AstigmatismImpl>
+      get copyWith => __$$VisionFilter_AstigmatismImplCopyWithImpl<
+          _$VisionFilter_AstigmatismImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return astigmatism(axisDeg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return astigmatism?.call(axisDeg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (astigmatism != null) {
+      return astigmatism(axisDeg);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return astigmatism(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return astigmatism?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (astigmatism != null) {
+      return astigmatism(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Astigmatism extends VisionFilter {
+  const factory VisionFilter_Astigmatism({required final double axisDeg}) =
+      _$VisionFilter_AstigmatismImpl;
+  const VisionFilter_Astigmatism._() : super._();
+
+  double get axisDeg;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_AstigmatismImplCopyWith<_$VisionFilter_AstigmatismImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_GlaucomaImplCopyWith<$Res> {
+  factory _$$VisionFilter_GlaucomaImplCopyWith(
+          _$VisionFilter_GlaucomaImpl value,
+          $Res Function(_$VisionFilter_GlaucomaImpl) then) =
+      __$$VisionFilter_GlaucomaImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({VisionGlaucomaMode mode});
+}
+
+/// @nodoc
+class __$$VisionFilter_GlaucomaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_GlaucomaImpl>
+    implements _$$VisionFilter_GlaucomaImplCopyWith<$Res> {
+  __$$VisionFilter_GlaucomaImplCopyWithImpl(_$VisionFilter_GlaucomaImpl _value,
+      $Res Function(_$VisionFilter_GlaucomaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? mode = null,
+  }) {
+    return _then(_$VisionFilter_GlaucomaImpl(
+      mode: null == mode
+          ? _value.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as VisionGlaucomaMode,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_GlaucomaImpl extends VisionFilter_Glaucoma {
+  const _$VisionFilter_GlaucomaImpl({required this.mode}) : super._();
+
+  @override
+  final VisionGlaucomaMode mode;
+
+  @override
+  String toString() {
+    return 'VisionFilter.glaucoma(mode: $mode)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_GlaucomaImpl &&
+            (identical(other.mode, mode) || other.mode == mode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, mode);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_GlaucomaImplCopyWith<_$VisionFilter_GlaucomaImpl>
+      get copyWith => __$$VisionFilter_GlaucomaImplCopyWithImpl<
+          _$VisionFilter_GlaucomaImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return glaucoma(mode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return glaucoma?.call(mode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (glaucoma != null) {
+      return glaucoma(mode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return glaucoma(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return glaucoma?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (glaucoma != null) {
+      return glaucoma(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Glaucoma extends VisionFilter {
+  const factory VisionFilter_Glaucoma(
+      {required final VisionGlaucomaMode mode}) = _$VisionFilter_GlaucomaImpl;
+  const VisionFilter_Glaucoma._() : super._();
+
+  VisionGlaucomaMode get mode;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_GlaucomaImplCopyWith<_$VisionFilter_GlaucomaImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_MacularDegenerationImplCopyWith<$Res> {
+  factory _$$VisionFilter_MacularDegenerationImplCopyWith(
+          _$VisionFilter_MacularDegenerationImpl value,
+          $Res Function(_$VisionFilter_MacularDegenerationImpl) then) =
+      __$$VisionFilter_MacularDegenerationImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_MacularDegenerationImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res,
+        _$VisionFilter_MacularDegenerationImpl>
+    implements _$$VisionFilter_MacularDegenerationImplCopyWith<$Res> {
+  __$$VisionFilter_MacularDegenerationImplCopyWithImpl(
+      _$VisionFilter_MacularDegenerationImpl _value,
+      $Res Function(_$VisionFilter_MacularDegenerationImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_MacularDegenerationImpl
+    extends VisionFilter_MacularDegeneration {
+  const _$VisionFilter_MacularDegenerationImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.macularDegeneration()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_MacularDegenerationImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return macularDegeneration();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return macularDegeneration?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (macularDegeneration != null) {
+      return macularDegeneration();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return macularDegeneration(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return macularDegeneration?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (macularDegeneration != null) {
+      return macularDegeneration(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_MacularDegeneration extends VisionFilter {
+  const factory VisionFilter_MacularDegeneration() =
+      _$VisionFilter_MacularDegenerationImpl;
+  const VisionFilter_MacularDegeneration._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_HemianopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_HemianopiaImplCopyWith(
+          _$VisionFilter_HemianopiaImpl value,
+          $Res Function(_$VisionFilter_HemianopiaImpl) then) =
+      __$$VisionFilter_HemianopiaImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double side});
+}
+
+/// @nodoc
+class __$$VisionFilter_HemianopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_HemianopiaImpl>
+    implements _$$VisionFilter_HemianopiaImplCopyWith<$Res> {
+  __$$VisionFilter_HemianopiaImplCopyWithImpl(
+      _$VisionFilter_HemianopiaImpl _value,
+      $Res Function(_$VisionFilter_HemianopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? side = null,
+  }) {
+    return _then(_$VisionFilter_HemianopiaImpl(
+      side: null == side
+          ? _value.side
+          : side // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_HemianopiaImpl extends VisionFilter_Hemianopia {
+  const _$VisionFilter_HemianopiaImpl({required this.side}) : super._();
+
+  @override
+  final double side;
+
+  @override
+  String toString() {
+    return 'VisionFilter.hemianopia(side: $side)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_HemianopiaImpl &&
+            (identical(other.side, side) || other.side == side));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, side);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_HemianopiaImplCopyWith<_$VisionFilter_HemianopiaImpl>
+      get copyWith => __$$VisionFilter_HemianopiaImplCopyWithImpl<
+          _$VisionFilter_HemianopiaImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return hemianopia(side);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return hemianopia?.call(side);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (hemianopia != null) {
+      return hemianopia(side);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return hemianopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return hemianopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (hemianopia != null) {
+      return hemianopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Hemianopia extends VisionFilter {
+  const factory VisionFilter_Hemianopia({required final double side}) =
+      _$VisionFilter_HemianopiaImpl;
+  const VisionFilter_Hemianopia._() : super._();
+
+  double get side;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_HemianopiaImplCopyWith<_$VisionFilter_HemianopiaImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_TunnelVisionImplCopyWith<$Res> {
+  factory _$$VisionFilter_TunnelVisionImplCopyWith(
+          _$VisionFilter_TunnelVisionImpl value,
+          $Res Function(_$VisionFilter_TunnelVisionImpl) then) =
+      __$$VisionFilter_TunnelVisionImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_TunnelVisionImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_TunnelVisionImpl>
+    implements _$$VisionFilter_TunnelVisionImplCopyWith<$Res> {
+  __$$VisionFilter_TunnelVisionImplCopyWithImpl(
+      _$VisionFilter_TunnelVisionImpl _value,
+      $Res Function(_$VisionFilter_TunnelVisionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_TunnelVisionImpl extends VisionFilter_TunnelVision {
+  const _$VisionFilter_TunnelVisionImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.tunnelVision()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_TunnelVisionImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return tunnelVision();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return tunnelVision?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tunnelVision != null) {
+      return tunnelVision();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return tunnelVision(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return tunnelVision?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (tunnelVision != null) {
+      return tunnelVision(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_TunnelVision extends VisionFilter {
+  const factory VisionFilter_TunnelVision() = _$VisionFilter_TunnelVisionImpl;
+  const VisionFilter_TunnelVision._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_CataractImplCopyWith<$Res> {
+  factory _$$VisionFilter_CataractImplCopyWith(
+          _$VisionFilter_CataractImpl value,
+          $Res Function(_$VisionFilter_CataractImpl) then) =
+      __$$VisionFilter_CataractImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({BigInt seed});
+}
+
+/// @nodoc
+class __$$VisionFilter_CataractImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_CataractImpl>
+    implements _$$VisionFilter_CataractImplCopyWith<$Res> {
+  __$$VisionFilter_CataractImplCopyWithImpl(_$VisionFilter_CataractImpl _value,
+      $Res Function(_$VisionFilter_CataractImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? seed = null,
+  }) {
+    return _then(_$VisionFilter_CataractImpl(
+      seed: null == seed
+          ? _value.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_CataractImpl extends VisionFilter_Cataract {
+  const _$VisionFilter_CataractImpl({required this.seed}) : super._();
+
+  @override
+  final BigInt seed;
+
+  @override
+  String toString() {
+    return 'VisionFilter.cataract(seed: $seed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_CataractImpl &&
+            (identical(other.seed, seed) || other.seed == seed));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, seed);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_CataractImplCopyWith<_$VisionFilter_CataractImpl>
+      get copyWith => __$$VisionFilter_CataractImplCopyWithImpl<
+          _$VisionFilter_CataractImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return cataract(seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return cataract?.call(seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (cataract != null) {
+      return cataract(seed);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return cataract(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return cataract?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (cataract != null) {
+      return cataract(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Cataract extends VisionFilter {
+  const factory VisionFilter_Cataract({required final BigInt seed}) =
+      _$VisionFilter_CataractImpl;
+  const VisionFilter_Cataract._() : super._();
+
+  BigInt get seed;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_CataractImplCopyWith<_$VisionFilter_CataractImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_FloatersImplCopyWith<$Res> {
+  factory _$$VisionFilter_FloatersImplCopyWith(
+          _$VisionFilter_FloatersImpl value,
+          $Res Function(_$VisionFilter_FloatersImpl) then) =
+      __$$VisionFilter_FloatersImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {BigInt seed, double density, double size, double gazeX, double gazeY});
+}
+
+/// @nodoc
+class __$$VisionFilter_FloatersImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_FloatersImpl>
+    implements _$$VisionFilter_FloatersImplCopyWith<$Res> {
+  __$$VisionFilter_FloatersImplCopyWithImpl(_$VisionFilter_FloatersImpl _value,
+      $Res Function(_$VisionFilter_FloatersImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? seed = null,
+    Object? density = null,
+    Object? size = null,
+    Object? gazeX = null,
+    Object? gazeY = null,
+  }) {
+    return _then(_$VisionFilter_FloatersImpl(
+      seed: null == seed
+          ? _value.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+      density: null == density
+          ? _value.density
+          : density // ignore: cast_nullable_to_non_nullable
+              as double,
+      size: null == size
+          ? _value.size
+          : size // ignore: cast_nullable_to_non_nullable
+              as double,
+      gazeX: null == gazeX
+          ? _value.gazeX
+          : gazeX // ignore: cast_nullable_to_non_nullable
+              as double,
+      gazeY: null == gazeY
+          ? _value.gazeY
+          : gazeY // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_FloatersImpl extends VisionFilter_Floaters {
+  const _$VisionFilter_FloatersImpl(
+      {required this.seed,
+      required this.density,
+      required this.size,
+      required this.gazeX,
+      required this.gazeY})
+      : super._();
+
+  @override
+  final BigInt seed;
+  @override
+  final double density;
+  @override
+  final double size;
+  @override
+  final double gazeX;
+  @override
+  final double gazeY;
+
+  @override
+  String toString() {
+    return 'VisionFilter.floaters(seed: $seed, density: $density, size: $size, gazeX: $gazeX, gazeY: $gazeY)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_FloatersImpl &&
+            (identical(other.seed, seed) || other.seed == seed) &&
+            (identical(other.density, density) || other.density == density) &&
+            (identical(other.size, size) || other.size == size) &&
+            (identical(other.gazeX, gazeX) || other.gazeX == gazeX) &&
+            (identical(other.gazeY, gazeY) || other.gazeY == gazeY));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, seed, density, size, gazeX, gazeY);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_FloatersImplCopyWith<_$VisionFilter_FloatersImpl>
+      get copyWith => __$$VisionFilter_FloatersImplCopyWithImpl<
+          _$VisionFilter_FloatersImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return floaters(seed, density, size, gazeX, gazeY);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return floaters?.call(seed, density, size, gazeX, gazeY);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (floaters != null) {
+      return floaters(seed, density, size, gazeX, gazeY);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return floaters(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return floaters?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (floaters != null) {
+      return floaters(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Floaters extends VisionFilter {
+  const factory VisionFilter_Floaters(
+      {required final BigInt seed,
+      required final double density,
+      required final double size,
+      required final double gazeX,
+      required final double gazeY}) = _$VisionFilter_FloatersImpl;
+  const VisionFilter_Floaters._() : super._();
+
+  BigInt get seed;
+  double get density;
+  double get size;
+  double get gazeX;
+  double get gazeY;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_FloatersImplCopyWith<_$VisionFilter_FloatersImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_PhotophobiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_PhotophobiaImplCopyWith(
+          _$VisionFilter_PhotophobiaImpl value,
+          $Res Function(_$VisionFilter_PhotophobiaImpl) then) =
+      __$$VisionFilter_PhotophobiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_PhotophobiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_PhotophobiaImpl>
+    implements _$$VisionFilter_PhotophobiaImplCopyWith<$Res> {
+  __$$VisionFilter_PhotophobiaImplCopyWithImpl(
+      _$VisionFilter_PhotophobiaImpl _value,
+      $Res Function(_$VisionFilter_PhotophobiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_PhotophobiaImpl extends VisionFilter_Photophobia {
+  const _$VisionFilter_PhotophobiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.photophobia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_PhotophobiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return photophobia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return photophobia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (photophobia != null) {
+      return photophobia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return photophobia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return photophobia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (photophobia != null) {
+      return photophobia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Photophobia extends VisionFilter {
+  const factory VisionFilter_Photophobia() = _$VisionFilter_PhotophobiaImpl;
+  const VisionFilter_Photophobia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_NightBlindnessImplCopyWith<$Res> {
+  factory _$$VisionFilter_NightBlindnessImplCopyWith(
+          _$VisionFilter_NightBlindnessImpl value,
+          $Res Function(_$VisionFilter_NightBlindnessImpl) then) =
+      __$$VisionFilter_NightBlindnessImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_NightBlindnessImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_NightBlindnessImpl>
+    implements _$$VisionFilter_NightBlindnessImplCopyWith<$Res> {
+  __$$VisionFilter_NightBlindnessImplCopyWithImpl(
+      _$VisionFilter_NightBlindnessImpl _value,
+      $Res Function(_$VisionFilter_NightBlindnessImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_NightBlindnessImpl extends VisionFilter_NightBlindness {
+  const _$VisionFilter_NightBlindnessImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.nightBlindness()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_NightBlindnessImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return nightBlindness();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return nightBlindness?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (nightBlindness != null) {
+      return nightBlindness();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return nightBlindness(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return nightBlindness?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (nightBlindness != null) {
+      return nightBlindness(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_NightBlindness extends VisionFilter {
+  const factory VisionFilter_NightBlindness() =
+      _$VisionFilter_NightBlindnessImpl;
+  const VisionFilter_NightBlindness._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_VertigoImplCopyWith<$Res> {
+  factory _$$VisionFilter_VertigoImplCopyWith(_$VisionFilter_VertigoImpl value,
+          $Res Function(_$VisionFilter_VertigoImpl) then) =
+      __$$VisionFilter_VertigoImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_VertigoImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_VertigoImpl>
+    implements _$$VisionFilter_VertigoImplCopyWith<$Res> {
+  __$$VisionFilter_VertigoImplCopyWithImpl(_$VisionFilter_VertigoImpl _value,
+      $Res Function(_$VisionFilter_VertigoImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_VertigoImpl extends VisionFilter_Vertigo {
+  const _$VisionFilter_VertigoImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.vertigo()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_VertigoImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return vertigo();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return vertigo?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (vertigo != null) {
+      return vertigo();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return vertigo(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return vertigo?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (vertigo != null) {
+      return vertigo(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Vertigo extends VisionFilter {
+  const factory VisionFilter_Vertigo() = _$VisionFilter_VertigoImpl;
+  const VisionFilter_Vertigo._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_BppvRotationImplCopyWith<$Res> {
+  factory _$$VisionFilter_BppvRotationImplCopyWith(
+          _$VisionFilter_BppvRotationImpl value,
+          $Res Function(_$VisionFilter_BppvRotationImpl) then) =
+      __$$VisionFilter_BppvRotationImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_BppvRotationImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_BppvRotationImpl>
+    implements _$$VisionFilter_BppvRotationImplCopyWith<$Res> {
+  __$$VisionFilter_BppvRotationImplCopyWithImpl(
+      _$VisionFilter_BppvRotationImpl _value,
+      $Res Function(_$VisionFilter_BppvRotationImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_BppvRotationImpl extends VisionFilter_BppvRotation {
+  const _$VisionFilter_BppvRotationImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.bppvRotation()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_BppvRotationImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return bppvRotation();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return bppvRotation?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (bppvRotation != null) {
+      return bppvRotation();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return bppvRotation(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return bppvRotation?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (bppvRotation != null) {
+      return bppvRotation(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_BppvRotation extends VisionFilter {
+  const factory VisionFilter_BppvRotation() = _$VisionFilter_BppvRotationImpl;
+  const VisionFilter_BppvRotation._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_VestibularNeuritisImplCopyWith<$Res> {
+  factory _$$VisionFilter_VestibularNeuritisImplCopyWith(
+          _$VisionFilter_VestibularNeuritisImpl value,
+          $Res Function(_$VisionFilter_VestibularNeuritisImpl) then) =
+      __$$VisionFilter_VestibularNeuritisImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_VestibularNeuritisImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res,
+        _$VisionFilter_VestibularNeuritisImpl>
+    implements _$$VisionFilter_VestibularNeuritisImplCopyWith<$Res> {
+  __$$VisionFilter_VestibularNeuritisImplCopyWithImpl(
+      _$VisionFilter_VestibularNeuritisImpl _value,
+      $Res Function(_$VisionFilter_VestibularNeuritisImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_VestibularNeuritisImpl
+    extends VisionFilter_VestibularNeuritis {
+  const _$VisionFilter_VestibularNeuritisImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.vestibularNeuritis()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_VestibularNeuritisImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return vestibularNeuritis();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return vestibularNeuritis?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (vestibularNeuritis != null) {
+      return vestibularNeuritis();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return vestibularNeuritis(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return vestibularNeuritis?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (vestibularNeuritis != null) {
+      return vestibularNeuritis(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_VestibularNeuritis extends VisionFilter {
+  const factory VisionFilter_VestibularNeuritis() =
+      _$VisionFilter_VestibularNeuritisImpl;
+  const VisionFilter_VestibularNeuritis._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_DiplopiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_DiplopiaImplCopyWith(
+          _$VisionFilter_DiplopiaImpl value,
+          $Res Function(_$VisionFilter_DiplopiaImpl) then) =
+      __$$VisionFilter_DiplopiaImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double offsetX, double offsetY, double ghostStrength});
+}
+
+/// @nodoc
+class __$$VisionFilter_DiplopiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_DiplopiaImpl>
+    implements _$$VisionFilter_DiplopiaImplCopyWith<$Res> {
+  __$$VisionFilter_DiplopiaImplCopyWithImpl(_$VisionFilter_DiplopiaImpl _value,
+      $Res Function(_$VisionFilter_DiplopiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? offsetX = null,
+    Object? offsetY = null,
+    Object? ghostStrength = null,
+  }) {
+    return _then(_$VisionFilter_DiplopiaImpl(
+      offsetX: null == offsetX
+          ? _value.offsetX
+          : offsetX // ignore: cast_nullable_to_non_nullable
+              as double,
+      offsetY: null == offsetY
+          ? _value.offsetY
+          : offsetY // ignore: cast_nullable_to_non_nullable
+              as double,
+      ghostStrength: null == ghostStrength
+          ? _value.ghostStrength
+          : ghostStrength // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_DiplopiaImpl extends VisionFilter_Diplopia {
+  const _$VisionFilter_DiplopiaImpl(
+      {required this.offsetX,
+      required this.offsetY,
+      required this.ghostStrength})
+      : super._();
+
+  @override
+  final double offsetX;
+  @override
+  final double offsetY;
+  @override
+  final double ghostStrength;
+
+  @override
+  String toString() {
+    return 'VisionFilter.diplopia(offsetX: $offsetX, offsetY: $offsetY, ghostStrength: $ghostStrength)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_DiplopiaImpl &&
+            (identical(other.offsetX, offsetX) || other.offsetX == offsetX) &&
+            (identical(other.offsetY, offsetY) || other.offsetY == offsetY) &&
+            (identical(other.ghostStrength, ghostStrength) ||
+                other.ghostStrength == ghostStrength));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, offsetX, offsetY, ghostStrength);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_DiplopiaImplCopyWith<_$VisionFilter_DiplopiaImpl>
+      get copyWith => __$$VisionFilter_DiplopiaImplCopyWithImpl<
+          _$VisionFilter_DiplopiaImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return diplopia(offsetX, offsetY, ghostStrength);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return diplopia?.call(offsetX, offsetY, ghostStrength);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (diplopia != null) {
+      return diplopia(offsetX, offsetY, ghostStrength);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return diplopia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return diplopia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (diplopia != null) {
+      return diplopia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Diplopia extends VisionFilter {
+  const factory VisionFilter_Diplopia(
+      {required final double offsetX,
+      required final double offsetY,
+      required final double ghostStrength}) = _$VisionFilter_DiplopiaImpl;
+  const VisionFilter_Diplopia._() : super._();
+
+  double get offsetX;
+  double get offsetY;
+  double get ghostStrength;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_DiplopiaImplCopyWith<_$VisionFilter_DiplopiaImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_NystagmusImplCopyWith<$Res> {
+  factory _$$VisionFilter_NystagmusImplCopyWith(
+          _$VisionFilter_NystagmusImpl value,
+          $Res Function(_$VisionFilter_NystagmusImpl) then) =
+      __$$VisionFilter_NystagmusImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double amplitude, double directionDeg});
+}
+
+/// @nodoc
+class __$$VisionFilter_NystagmusImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_NystagmusImpl>
+    implements _$$VisionFilter_NystagmusImplCopyWith<$Res> {
+  __$$VisionFilter_NystagmusImplCopyWithImpl(
+      _$VisionFilter_NystagmusImpl _value,
+      $Res Function(_$VisionFilter_NystagmusImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? amplitude = null,
+    Object? directionDeg = null,
+  }) {
+    return _then(_$VisionFilter_NystagmusImpl(
+      amplitude: null == amplitude
+          ? _value.amplitude
+          : amplitude // ignore: cast_nullable_to_non_nullable
+              as double,
+      directionDeg: null == directionDeg
+          ? _value.directionDeg
+          : directionDeg // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_NystagmusImpl extends VisionFilter_Nystagmus {
+  const _$VisionFilter_NystagmusImpl(
+      {required this.amplitude, required this.directionDeg})
+      : super._();
+
+  @override
+  final double amplitude;
+  @override
+  final double directionDeg;
+
+  @override
+  String toString() {
+    return 'VisionFilter.nystagmus(amplitude: $amplitude, directionDeg: $directionDeg)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_NystagmusImpl &&
+            (identical(other.amplitude, amplitude) ||
+                other.amplitude == amplitude) &&
+            (identical(other.directionDeg, directionDeg) ||
+                other.directionDeg == directionDeg));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, amplitude, directionDeg);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_NystagmusImplCopyWith<_$VisionFilter_NystagmusImpl>
+      get copyWith => __$$VisionFilter_NystagmusImplCopyWithImpl<
+          _$VisionFilter_NystagmusImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return nystagmus(amplitude, directionDeg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return nystagmus?.call(amplitude, directionDeg);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (nystagmus != null) {
+      return nystagmus(amplitude, directionDeg);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return nystagmus(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return nystagmus?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (nystagmus != null) {
+      return nystagmus(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Nystagmus extends VisionFilter {
+  const factory VisionFilter_Nystagmus(
+      {required final double amplitude,
+      required final double directionDeg}) = _$VisionFilter_NystagmusImpl;
+  const VisionFilter_Nystagmus._() : super._();
+
+  double get amplitude;
+  double get directionDeg;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_NystagmusImplCopyWith<_$VisionFilter_NystagmusImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_StarburstsImplCopyWith<$Res> {
+  factory _$$VisionFilter_StarburstsImplCopyWith(
+          _$VisionFilter_StarburstsImpl value,
+          $Res Function(_$VisionFilter_StarburstsImpl) then) =
+      __$$VisionFilter_StarburstsImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call(
+      {int numRays,
+      double rayLengthRatio,
+      double threshold,
+      double dispersion});
+}
+
+/// @nodoc
+class __$$VisionFilter_StarburstsImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_StarburstsImpl>
+    implements _$$VisionFilter_StarburstsImplCopyWith<$Res> {
+  __$$VisionFilter_StarburstsImplCopyWithImpl(
+      _$VisionFilter_StarburstsImpl _value,
+      $Res Function(_$VisionFilter_StarburstsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? numRays = null,
+    Object? rayLengthRatio = null,
+    Object? threshold = null,
+    Object? dispersion = null,
+  }) {
+    return _then(_$VisionFilter_StarburstsImpl(
+      numRays: null == numRays
+          ? _value.numRays
+          : numRays // ignore: cast_nullable_to_non_nullable
+              as int,
+      rayLengthRatio: null == rayLengthRatio
+          ? _value.rayLengthRatio
+          : rayLengthRatio // ignore: cast_nullable_to_non_nullable
+              as double,
+      threshold: null == threshold
+          ? _value.threshold
+          : threshold // ignore: cast_nullable_to_non_nullable
+              as double,
+      dispersion: null == dispersion
+          ? _value.dispersion
+          : dispersion // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_StarburstsImpl extends VisionFilter_Starbursts {
+  const _$VisionFilter_StarburstsImpl(
+      {required this.numRays,
+      required this.rayLengthRatio,
+      required this.threshold,
+      required this.dispersion})
+      : super._();
+
+  @override
+  final int numRays;
+  @override
+  final double rayLengthRatio;
+  @override
+  final double threshold;
+  @override
+  final double dispersion;
+
+  @override
+  String toString() {
+    return 'VisionFilter.starbursts(numRays: $numRays, rayLengthRatio: $rayLengthRatio, threshold: $threshold, dispersion: $dispersion)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_StarburstsImpl &&
+            (identical(other.numRays, numRays) || other.numRays == numRays) &&
+            (identical(other.rayLengthRatio, rayLengthRatio) ||
+                other.rayLengthRatio == rayLengthRatio) &&
+            (identical(other.threshold, threshold) ||
+                other.threshold == threshold) &&
+            (identical(other.dispersion, dispersion) ||
+                other.dispersion == dispersion));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, numRays, rayLengthRatio, threshold, dispersion);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_StarburstsImplCopyWith<_$VisionFilter_StarburstsImpl>
+      get copyWith => __$$VisionFilter_StarburstsImplCopyWithImpl<
+          _$VisionFilter_StarburstsImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return starbursts(numRays, rayLengthRatio, threshold, dispersion);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return starbursts?.call(numRays, rayLengthRatio, threshold, dispersion);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (starbursts != null) {
+      return starbursts(numRays, rayLengthRatio, threshold, dispersion);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return starbursts(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return starbursts?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (starbursts != null) {
+      return starbursts(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Starbursts extends VisionFilter {
+  const factory VisionFilter_Starbursts(
+      {required final int numRays,
+      required final double rayLengthRatio,
+      required final double threshold,
+      required final double dispersion}) = _$VisionFilter_StarburstsImpl;
+  const VisionFilter_Starbursts._() : super._();
+
+  int get numRays;
+  double get rayLengthRatio;
+  double get threshold;
+  double get dispersion;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_StarburstsImplCopyWith<_$VisionFilter_StarburstsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_EyeStrainImplCopyWith<$Res> {
+  factory _$$VisionFilter_EyeStrainImplCopyWith(
+          _$VisionFilter_EyeStrainImpl value,
+          $Res Function(_$VisionFilter_EyeStrainImpl) then) =
+      __$$VisionFilter_EyeStrainImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_EyeStrainImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_EyeStrainImpl>
+    implements _$$VisionFilter_EyeStrainImplCopyWith<$Res> {
+  __$$VisionFilter_EyeStrainImplCopyWithImpl(
+      _$VisionFilter_EyeStrainImpl _value,
+      $Res Function(_$VisionFilter_EyeStrainImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_EyeStrainImpl extends VisionFilter_EyeStrain {
+  const _$VisionFilter_EyeStrainImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.eyeStrain()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_EyeStrainImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return eyeStrain();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return eyeStrain?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (eyeStrain != null) {
+      return eyeStrain();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return eyeStrain(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return eyeStrain?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (eyeStrain != null) {
+      return eyeStrain(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_EyeStrain extends VisionFilter {
+  const factory VisionFilter_EyeStrain() = _$VisionFilter_EyeStrainImpl;
+  const VisionFilter_EyeStrain._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_DryEyeImplCopyWith<$Res> {
+  factory _$$VisionFilter_DryEyeImplCopyWith(_$VisionFilter_DryEyeImpl value,
+          $Res Function(_$VisionFilter_DryEyeImpl) then) =
+      __$$VisionFilter_DryEyeImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_DryEyeImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_DryEyeImpl>
+    implements _$$VisionFilter_DryEyeImplCopyWith<$Res> {
+  __$$VisionFilter_DryEyeImplCopyWithImpl(_$VisionFilter_DryEyeImpl _value,
+      $Res Function(_$VisionFilter_DryEyeImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_DryEyeImpl extends VisionFilter_DryEye {
+  const _$VisionFilter_DryEyeImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.dryEye()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_DryEyeImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return dryEye();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return dryEye?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (dryEye != null) {
+      return dryEye();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return dryEye(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return dryEye?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (dryEye != null) {
+      return dryEye(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_DryEye extends VisionFilter {
+  const factory VisionFilter_DryEye() = _$VisionFilter_DryEyeImpl;
+  const VisionFilter_DryEye._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_MetamorphopsiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_MetamorphopsiaImplCopyWith(
+          _$VisionFilter_MetamorphopsiaImpl value,
+          $Res Function(_$VisionFilter_MetamorphopsiaImpl) then) =
+      __$$VisionFilter_MetamorphopsiaImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double freq, BigInt seed});
+}
+
+/// @nodoc
+class __$$VisionFilter_MetamorphopsiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_MetamorphopsiaImpl>
+    implements _$$VisionFilter_MetamorphopsiaImplCopyWith<$Res> {
+  __$$VisionFilter_MetamorphopsiaImplCopyWithImpl(
+      _$VisionFilter_MetamorphopsiaImpl _value,
+      $Res Function(_$VisionFilter_MetamorphopsiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? freq = null,
+    Object? seed = null,
+  }) {
+    return _then(_$VisionFilter_MetamorphopsiaImpl(
+      freq: null == freq
+          ? _value.freq
+          : freq // ignore: cast_nullable_to_non_nullable
+              as double,
+      seed: null == seed
+          ? _value.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_MetamorphopsiaImpl extends VisionFilter_Metamorphopsia {
+  const _$VisionFilter_MetamorphopsiaImpl(
+      {required this.freq, required this.seed})
+      : super._();
+
+  @override
+  final double freq;
+  @override
+  final BigInt seed;
+
+  @override
+  String toString() {
+    return 'VisionFilter.metamorphopsia(freq: $freq, seed: $seed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_MetamorphopsiaImpl &&
+            (identical(other.freq, freq) || other.freq == freq) &&
+            (identical(other.seed, seed) || other.seed == seed));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, freq, seed);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_MetamorphopsiaImplCopyWith<_$VisionFilter_MetamorphopsiaImpl>
+      get copyWith => __$$VisionFilter_MetamorphopsiaImplCopyWithImpl<
+          _$VisionFilter_MetamorphopsiaImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return metamorphopsia(freq, seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return metamorphopsia?.call(freq, seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (metamorphopsia != null) {
+      return metamorphopsia(freq, seed);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return metamorphopsia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return metamorphopsia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (metamorphopsia != null) {
+      return metamorphopsia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Metamorphopsia extends VisionFilter {
+  const factory VisionFilter_Metamorphopsia(
+      {required final double freq,
+      required final BigInt seed}) = _$VisionFilter_MetamorphopsiaImpl;
+  const VisionFilter_Metamorphopsia._() : super._();
+
+  double get freq;
+  BigInt get seed;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_MetamorphopsiaImplCopyWith<_$VisionFilter_MetamorphopsiaImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_ContrastSensitivityImplCopyWith<$Res> {
+  factory _$$VisionFilter_ContrastSensitivityImplCopyWith(
+          _$VisionFilter_ContrastSensitivityImpl value,
+          $Res Function(_$VisionFilter_ContrastSensitivityImpl) then) =
+      __$$VisionFilter_ContrastSensitivityImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_ContrastSensitivityImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res,
+        _$VisionFilter_ContrastSensitivityImpl>
+    implements _$$VisionFilter_ContrastSensitivityImplCopyWith<$Res> {
+  __$$VisionFilter_ContrastSensitivityImplCopyWithImpl(
+      _$VisionFilter_ContrastSensitivityImpl _value,
+      $Res Function(_$VisionFilter_ContrastSensitivityImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_ContrastSensitivityImpl
+    extends VisionFilter_ContrastSensitivity {
+  const _$VisionFilter_ContrastSensitivityImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.contrastSensitivity()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_ContrastSensitivityImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return contrastSensitivity();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return contrastSensitivity?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (contrastSensitivity != null) {
+      return contrastSensitivity();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return contrastSensitivity(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return contrastSensitivity?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (contrastSensitivity != null) {
+      return contrastSensitivity(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_ContrastSensitivity extends VisionFilter {
+  const factory VisionFilter_ContrastSensitivity() =
+      _$VisionFilter_ContrastSensitivityImpl;
+  const VisionFilter_ContrastSensitivity._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_DetailLossImplCopyWith<$Res> {
+  factory _$$VisionFilter_DetailLossImplCopyWith(
+          _$VisionFilter_DetailLossImpl value,
+          $Res Function(_$VisionFilter_DetailLossImpl) then) =
+      __$$VisionFilter_DetailLossImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int cellSize});
+}
+
+/// @nodoc
+class __$$VisionFilter_DetailLossImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_DetailLossImpl>
+    implements _$$VisionFilter_DetailLossImplCopyWith<$Res> {
+  __$$VisionFilter_DetailLossImplCopyWithImpl(
+      _$VisionFilter_DetailLossImpl _value,
+      $Res Function(_$VisionFilter_DetailLossImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? cellSize = null,
+  }) {
+    return _then(_$VisionFilter_DetailLossImpl(
+      cellSize: null == cellSize
+          ? _value.cellSize
+          : cellSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_DetailLossImpl extends VisionFilter_DetailLoss {
+  const _$VisionFilter_DetailLossImpl({required this.cellSize}) : super._();
+
+  @override
+  final int cellSize;
+
+  @override
+  String toString() {
+    return 'VisionFilter.detailLoss(cellSize: $cellSize)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_DetailLossImpl &&
+            (identical(other.cellSize, cellSize) ||
+                other.cellSize == cellSize));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, cellSize);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_DetailLossImplCopyWith<_$VisionFilter_DetailLossImpl>
+      get copyWith => __$$VisionFilter_DetailLossImplCopyWithImpl<
+          _$VisionFilter_DetailLossImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return detailLoss(cellSize);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return detailLoss?.call(cellSize);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (detailLoss != null) {
+      return detailLoss(cellSize);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return detailLoss(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return detailLoss?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (detailLoss != null) {
+      return detailLoss(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_DetailLoss extends VisionFilter {
+  const factory VisionFilter_DetailLoss({required final int cellSize}) =
+      _$VisionFilter_DetailLossImpl;
+  const VisionFilter_DetailLoss._() : super._();
+
+  int get cellSize;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_DetailLossImplCopyWith<_$VisionFilter_DetailLossImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_TeichopsiaImplCopyWith<$Res> {
+  factory _$$VisionFilter_TeichopsiaImplCopyWith(
+          _$VisionFilter_TeichopsiaImpl value,
+          $Res Function(_$VisionFilter_TeichopsiaImpl) then) =
+      __$$VisionFilter_TeichopsiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$VisionFilter_TeichopsiaImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_TeichopsiaImpl>
+    implements _$$VisionFilter_TeichopsiaImplCopyWith<$Res> {
+  __$$VisionFilter_TeichopsiaImplCopyWithImpl(
+      _$VisionFilter_TeichopsiaImpl _value,
+      $Res Function(_$VisionFilter_TeichopsiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$VisionFilter_TeichopsiaImpl extends VisionFilter_Teichopsia {
+  const _$VisionFilter_TeichopsiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'VisionFilter.teichopsia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_TeichopsiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return teichopsia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return teichopsia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (teichopsia != null) {
+      return teichopsia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return teichopsia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return teichopsia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (teichopsia != null) {
+      return teichopsia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_Teichopsia extends VisionFilter {
+  const factory VisionFilter_Teichopsia() = _$VisionFilter_TeichopsiaImpl;
+  const VisionFilter_Teichopsia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$VisionFilter_FlickeringStarsImplCopyWith<$Res> {
+  factory _$$VisionFilter_FlickeringStarsImplCopyWith(
+          _$VisionFilter_FlickeringStarsImpl value,
+          $Res Function(_$VisionFilter_FlickeringStarsImpl) then) =
+      __$$VisionFilter_FlickeringStarsImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({BigInt seed});
+}
+
+/// @nodoc
+class __$$VisionFilter_FlickeringStarsImplCopyWithImpl<$Res>
+    extends _$VisionFilterCopyWithImpl<$Res, _$VisionFilter_FlickeringStarsImpl>
+    implements _$$VisionFilter_FlickeringStarsImplCopyWith<$Res> {
+  __$$VisionFilter_FlickeringStarsImplCopyWithImpl(
+      _$VisionFilter_FlickeringStarsImpl _value,
+      $Res Function(_$VisionFilter_FlickeringStarsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? seed = null,
+  }) {
+    return _then(_$VisionFilter_FlickeringStarsImpl(
+      seed: null == seed
+          ? _value.seed
+          : seed // ignore: cast_nullable_to_non_nullable
+              as BigInt,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$VisionFilter_FlickeringStarsImpl extends VisionFilter_FlickeringStars {
+  const _$VisionFilter_FlickeringStarsImpl({required this.seed}) : super._();
+
+  @override
+  final BigInt seed;
+
+  @override
+  String toString() {
+    return 'VisionFilter.flickeringStars(seed: $seed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$VisionFilter_FlickeringStarsImpl &&
+            (identical(other.seed, seed) || other.seed == seed));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, seed);
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$VisionFilter_FlickeringStarsImplCopyWith<
+          _$VisionFilter_FlickeringStarsImpl>
+      get copyWith => __$$VisionFilter_FlickeringStarsImplCopyWithImpl<
+          _$VisionFilter_FlickeringStarsImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() protanopia,
+    required TResult Function() deuteranopia,
+    required TResult Function() tritanopia,
+    required TResult Function() achromatopsia,
+    required TResult Function() tetrachromacy,
+    required TResult Function() myopia,
+    required TResult Function() hyperopia,
+    required TResult Function() presbyopia,
+    required TResult Function(double axisDeg) astigmatism,
+    required TResult Function(VisionGlaucomaMode mode) glaucoma,
+    required TResult Function() macularDegeneration,
+    required TResult Function(double side) hemianopia,
+    required TResult Function() tunnelVision,
+    required TResult Function(BigInt seed) cataract,
+    required TResult Function(BigInt seed, double density, double size,
+            double gazeX, double gazeY)
+        floaters,
+    required TResult Function() photophobia,
+    required TResult Function() nightBlindness,
+    required TResult Function() vertigo,
+    required TResult Function() bppvRotation,
+    required TResult Function() vestibularNeuritis,
+    required TResult Function(
+            double offsetX, double offsetY, double ghostStrength)
+        diplopia,
+    required TResult Function(double amplitude, double directionDeg) nystagmus,
+    required TResult Function(int numRays, double rayLengthRatio,
+            double threshold, double dispersion)
+        starbursts,
+    required TResult Function() eyeStrain,
+    required TResult Function() dryEye,
+    required TResult Function(double freq, BigInt seed) metamorphopsia,
+    required TResult Function() contrastSensitivity,
+    required TResult Function(int cellSize) detailLoss,
+    required TResult Function() teichopsia,
+    required TResult Function(BigInt seed) flickeringStars,
+  }) {
+    return flickeringStars(seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? protanopia,
+    TResult? Function()? deuteranopia,
+    TResult? Function()? tritanopia,
+    TResult? Function()? achromatopsia,
+    TResult? Function()? tetrachromacy,
+    TResult? Function()? myopia,
+    TResult? Function()? hyperopia,
+    TResult? Function()? presbyopia,
+    TResult? Function(double axisDeg)? astigmatism,
+    TResult? Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult? Function()? macularDegeneration,
+    TResult? Function(double side)? hemianopia,
+    TResult? Function()? tunnelVision,
+    TResult? Function(BigInt seed)? cataract,
+    TResult? Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult? Function()? photophobia,
+    TResult? Function()? nightBlindness,
+    TResult? Function()? vertigo,
+    TResult? Function()? bppvRotation,
+    TResult? Function()? vestibularNeuritis,
+    TResult? Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult? Function(double amplitude, double directionDeg)? nystagmus,
+    TResult? Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult? Function()? eyeStrain,
+    TResult? Function()? dryEye,
+    TResult? Function(double freq, BigInt seed)? metamorphopsia,
+    TResult? Function()? contrastSensitivity,
+    TResult? Function(int cellSize)? detailLoss,
+    TResult? Function()? teichopsia,
+    TResult? Function(BigInt seed)? flickeringStars,
+  }) {
+    return flickeringStars?.call(seed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? protanopia,
+    TResult Function()? deuteranopia,
+    TResult Function()? tritanopia,
+    TResult Function()? achromatopsia,
+    TResult Function()? tetrachromacy,
+    TResult Function()? myopia,
+    TResult Function()? hyperopia,
+    TResult Function()? presbyopia,
+    TResult Function(double axisDeg)? astigmatism,
+    TResult Function(VisionGlaucomaMode mode)? glaucoma,
+    TResult Function()? macularDegeneration,
+    TResult Function(double side)? hemianopia,
+    TResult Function()? tunnelVision,
+    TResult Function(BigInt seed)? cataract,
+    TResult Function(BigInt seed, double density, double size, double gazeX,
+            double gazeY)?
+        floaters,
+    TResult Function()? photophobia,
+    TResult Function()? nightBlindness,
+    TResult Function()? vertigo,
+    TResult Function()? bppvRotation,
+    TResult Function()? vestibularNeuritis,
+    TResult Function(double offsetX, double offsetY, double ghostStrength)?
+        diplopia,
+    TResult Function(double amplitude, double directionDeg)? nystagmus,
+    TResult Function(int numRays, double rayLengthRatio, double threshold,
+            double dispersion)?
+        starbursts,
+    TResult Function()? eyeStrain,
+    TResult Function()? dryEye,
+    TResult Function(double freq, BigInt seed)? metamorphopsia,
+    TResult Function()? contrastSensitivity,
+    TResult Function(int cellSize)? detailLoss,
+    TResult Function()? teichopsia,
+    TResult Function(BigInt seed)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (flickeringStars != null) {
+      return flickeringStars(seed);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(VisionFilter_Protanopia value) protanopia,
+    required TResult Function(VisionFilter_Deuteranopia value) deuteranopia,
+    required TResult Function(VisionFilter_Tritanopia value) tritanopia,
+    required TResult Function(VisionFilter_Achromatopsia value) achromatopsia,
+    required TResult Function(VisionFilter_Tetrachromacy value) tetrachromacy,
+    required TResult Function(VisionFilter_Myopia value) myopia,
+    required TResult Function(VisionFilter_Hyperopia value) hyperopia,
+    required TResult Function(VisionFilter_Presbyopia value) presbyopia,
+    required TResult Function(VisionFilter_Astigmatism value) astigmatism,
+    required TResult Function(VisionFilter_Glaucoma value) glaucoma,
+    required TResult Function(VisionFilter_MacularDegeneration value)
+        macularDegeneration,
+    required TResult Function(VisionFilter_Hemianopia value) hemianopia,
+    required TResult Function(VisionFilter_TunnelVision value) tunnelVision,
+    required TResult Function(VisionFilter_Cataract value) cataract,
+    required TResult Function(VisionFilter_Floaters value) floaters,
+    required TResult Function(VisionFilter_Photophobia value) photophobia,
+    required TResult Function(VisionFilter_NightBlindness value) nightBlindness,
+    required TResult Function(VisionFilter_Vertigo value) vertigo,
+    required TResult Function(VisionFilter_BppvRotation value) bppvRotation,
+    required TResult Function(VisionFilter_VestibularNeuritis value)
+        vestibularNeuritis,
+    required TResult Function(VisionFilter_Diplopia value) diplopia,
+    required TResult Function(VisionFilter_Nystagmus value) nystagmus,
+    required TResult Function(VisionFilter_Starbursts value) starbursts,
+    required TResult Function(VisionFilter_EyeStrain value) eyeStrain,
+    required TResult Function(VisionFilter_DryEye value) dryEye,
+    required TResult Function(VisionFilter_Metamorphopsia value) metamorphopsia,
+    required TResult Function(VisionFilter_ContrastSensitivity value)
+        contrastSensitivity,
+    required TResult Function(VisionFilter_DetailLoss value) detailLoss,
+    required TResult Function(VisionFilter_Teichopsia value) teichopsia,
+    required TResult Function(VisionFilter_FlickeringStars value)
+        flickeringStars,
+  }) {
+    return flickeringStars(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(VisionFilter_Protanopia value)? protanopia,
+    TResult? Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult? Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult? Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult? Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult? Function(VisionFilter_Myopia value)? myopia,
+    TResult? Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult? Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult? Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult? Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult? Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult? Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult? Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult? Function(VisionFilter_Cataract value)? cataract,
+    TResult? Function(VisionFilter_Floaters value)? floaters,
+    TResult? Function(VisionFilter_Photophobia value)? photophobia,
+    TResult? Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult? Function(VisionFilter_Vertigo value)? vertigo,
+    TResult? Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult? Function(VisionFilter_VestibularNeuritis value)?
+        vestibularNeuritis,
+    TResult? Function(VisionFilter_Diplopia value)? diplopia,
+    TResult? Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult? Function(VisionFilter_Starbursts value)? starbursts,
+    TResult? Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult? Function(VisionFilter_DryEye value)? dryEye,
+    TResult? Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult? Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult? Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult? Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult? Function(VisionFilter_FlickeringStars value)? flickeringStars,
+  }) {
+    return flickeringStars?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(VisionFilter_Protanopia value)? protanopia,
+    TResult Function(VisionFilter_Deuteranopia value)? deuteranopia,
+    TResult Function(VisionFilter_Tritanopia value)? tritanopia,
+    TResult Function(VisionFilter_Achromatopsia value)? achromatopsia,
+    TResult Function(VisionFilter_Tetrachromacy value)? tetrachromacy,
+    TResult Function(VisionFilter_Myopia value)? myopia,
+    TResult Function(VisionFilter_Hyperopia value)? hyperopia,
+    TResult Function(VisionFilter_Presbyopia value)? presbyopia,
+    TResult Function(VisionFilter_Astigmatism value)? astigmatism,
+    TResult Function(VisionFilter_Glaucoma value)? glaucoma,
+    TResult Function(VisionFilter_MacularDegeneration value)?
+        macularDegeneration,
+    TResult Function(VisionFilter_Hemianopia value)? hemianopia,
+    TResult Function(VisionFilter_TunnelVision value)? tunnelVision,
+    TResult Function(VisionFilter_Cataract value)? cataract,
+    TResult Function(VisionFilter_Floaters value)? floaters,
+    TResult Function(VisionFilter_Photophobia value)? photophobia,
+    TResult Function(VisionFilter_NightBlindness value)? nightBlindness,
+    TResult Function(VisionFilter_Vertigo value)? vertigo,
+    TResult Function(VisionFilter_BppvRotation value)? bppvRotation,
+    TResult Function(VisionFilter_VestibularNeuritis value)? vestibularNeuritis,
+    TResult Function(VisionFilter_Diplopia value)? diplopia,
+    TResult Function(VisionFilter_Nystagmus value)? nystagmus,
+    TResult Function(VisionFilter_Starbursts value)? starbursts,
+    TResult Function(VisionFilter_EyeStrain value)? eyeStrain,
+    TResult Function(VisionFilter_DryEye value)? dryEye,
+    TResult Function(VisionFilter_Metamorphopsia value)? metamorphopsia,
+    TResult Function(VisionFilter_ContrastSensitivity value)?
+        contrastSensitivity,
+    TResult Function(VisionFilter_DetailLoss value)? detailLoss,
+    TResult Function(VisionFilter_Teichopsia value)? teichopsia,
+    TResult Function(VisionFilter_FlickeringStars value)? flickeringStars,
+    required TResult orElse(),
+  }) {
+    if (flickeringStars != null) {
+      return flickeringStars(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class VisionFilter_FlickeringStars extends VisionFilter {
+  const factory VisionFilter_FlickeringStars({required final BigInt seed}) =
+      _$VisionFilter_FlickeringStarsImpl;
+  const VisionFilter_FlickeringStars._() : super._();
+
+  BigInt get seed;
+
+  /// Create a copy of VisionFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$VisionFilter_FlickeringStarsImplCopyWith<
+          _$VisionFilter_FlickeringStarsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -94,9 +94,9 @@ abstract class RustLibApi extends BaseApi {
   Float32List crateApiSensusBridgeVisionUniforms(
       {required VisionFilter filter,
       required double strength,
+      required double time,
       required int width,
-      required int height,
-      required BigInt seed});
+      required int height});
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -116,7 +116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       required double strength}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_vision_filter(filter);
+        var arg0 = cst_encode_box_autoadd_vision_filter(filter);
         var arg1 = cst_encode_list_prim_u_8_loose(rgba8);
         var arg2 = cst_encode_u_32(width);
         var arg3 = cst_encode_u_32(height);
@@ -144,7 +144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String crateApiSensusBridgeVisionShaderGlsl({required VisionFilter filter}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_vision_filter(filter);
+        var arg0 = cst_encode_box_autoadd_vision_filter(filter);
         return wire.wire__crate__api__sensus_bridge__vision_shader_glsl(arg0);
       },
       codec: DcoCodec(
@@ -168,7 +168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       {required VisionFilter filter}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_vision_filter(filter);
+        var arg0 = cst_encode_box_autoadd_vision_filter(filter);
         return wire
             .wire__crate__api__sensus_bridge__vision_uniform_layout(arg0);
       },
@@ -192,16 +192,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Float32List crateApiSensusBridgeVisionUniforms(
       {required VisionFilter filter,
       required double strength,
+      required double time,
       required int width,
-      required int height,
-      required BigInt seed}) {
+      required int height}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
-        var arg0 = cst_encode_vision_filter(filter);
+        var arg0 = cst_encode_box_autoadd_vision_filter(filter);
         var arg1 = cst_encode_f_32(strength);
-        var arg2 = cst_encode_u_32(width);
-        var arg3 = cst_encode_u_32(height);
-        var arg4 = cst_encode_u_64(seed);
+        var arg2 = cst_encode_f_32(time);
+        var arg3 = cst_encode_u_32(width);
+        var arg4 = cst_encode_u_32(height);
         return wire.wire__crate__api__sensus_bridge__vision_uniforms(
             arg0, arg1, arg2, arg3, arg4);
       },
@@ -210,7 +210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: null,
       ),
       constMeta: kCrateApiSensusBridgeVisionUniformsConstMeta,
-      argValues: [filter, strength, width, height, seed],
+      argValues: [filter, strength, time, width, height],
       apiImpl: this,
     ));
   }
@@ -218,13 +218,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSensusBridgeVisionUniformsConstMeta =>
       const TaskConstMeta(
         debugName: 'vision_uniforms',
-        argNames: ['filter', 'strength', 'width', 'height', 'seed'],
+        argNames: ['filter', 'strength', 'time', 'width', 'height'],
       );
 
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as String;
+  }
+
+  @protected
+  VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_vision_filter(raw);
   }
 
   @protected
@@ -290,7 +296,109 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   VisionFilter dco_decode_vision_filter(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
-    return VisionFilter.values[raw as int];
+    switch (raw[0]) {
+      case 0:
+        return const VisionFilter_Protanopia();
+      case 1:
+        return const VisionFilter_Deuteranopia();
+      case 2:
+        return const VisionFilter_Tritanopia();
+      case 3:
+        return const VisionFilter_Achromatopsia();
+      case 4:
+        return const VisionFilter_Tetrachromacy();
+      case 5:
+        return const VisionFilter_Myopia();
+      case 6:
+        return const VisionFilter_Hyperopia();
+      case 7:
+        return const VisionFilter_Presbyopia();
+      case 8:
+        return VisionFilter_Astigmatism(
+          axisDeg: dco_decode_f_32(raw[1]),
+        );
+      case 9:
+        return VisionFilter_Glaucoma(
+          mode: dco_decode_vision_glaucoma_mode(raw[1]),
+        );
+      case 10:
+        return const VisionFilter_MacularDegeneration();
+      case 11:
+        return VisionFilter_Hemianopia(
+          side: dco_decode_f_32(raw[1]),
+        );
+      case 12:
+        return const VisionFilter_TunnelVision();
+      case 13:
+        return VisionFilter_Cataract(
+          seed: dco_decode_u_64(raw[1]),
+        );
+      case 14:
+        return VisionFilter_Floaters(
+          seed: dco_decode_u_64(raw[1]),
+          density: dco_decode_f_32(raw[2]),
+          size: dco_decode_f_32(raw[3]),
+          gazeX: dco_decode_f_32(raw[4]),
+          gazeY: dco_decode_f_32(raw[5]),
+        );
+      case 15:
+        return const VisionFilter_Photophobia();
+      case 16:
+        return const VisionFilter_NightBlindness();
+      case 17:
+        return const VisionFilter_Vertigo();
+      case 18:
+        return const VisionFilter_BppvRotation();
+      case 19:
+        return const VisionFilter_VestibularNeuritis();
+      case 20:
+        return VisionFilter_Diplopia(
+          offsetX: dco_decode_f_32(raw[1]),
+          offsetY: dco_decode_f_32(raw[2]),
+          ghostStrength: dco_decode_f_32(raw[3]),
+        );
+      case 21:
+        return VisionFilter_Nystagmus(
+          amplitude: dco_decode_f_32(raw[1]),
+          directionDeg: dco_decode_f_32(raw[2]),
+        );
+      case 22:
+        return VisionFilter_Starbursts(
+          numRays: dco_decode_u_32(raw[1]),
+          rayLengthRatio: dco_decode_f_32(raw[2]),
+          threshold: dco_decode_f_32(raw[3]),
+          dispersion: dco_decode_f_32(raw[4]),
+        );
+      case 23:
+        return const VisionFilter_EyeStrain();
+      case 24:
+        return const VisionFilter_DryEye();
+      case 25:
+        return VisionFilter_Metamorphopsia(
+          freq: dco_decode_f_32(raw[1]),
+          seed: dco_decode_u_64(raw[2]),
+        );
+      case 26:
+        return const VisionFilter_ContrastSensitivity();
+      case 27:
+        return VisionFilter_DetailLoss(
+          cellSize: dco_decode_u_32(raw[1]),
+        );
+      case 28:
+        return const VisionFilter_Teichopsia();
+      case 29:
+        return VisionFilter_FlickeringStars(
+          seed: dco_decode_u_64(raw[1]),
+        );
+      default:
+        throw Exception('unreachable');
+    }
+  }
+
+  @protected
+  VisionGlaucomaMode dco_decode_vision_glaucoma_mode(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return VisionGlaucomaMode.values[raw as int];
   }
 
   @protected
@@ -298,6 +406,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
     return utf8.decoder.convert(inner);
+  }
+
+  @protected
+  VisionFilter sse_decode_box_autoadd_vision_filter(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_vision_filter(deserializer));
   }
 
   @protected
@@ -371,8 +486,115 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   VisionFilter sse_decode_vision_filter(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return const VisionFilter_Protanopia();
+      case 1:
+        return const VisionFilter_Deuteranopia();
+      case 2:
+        return const VisionFilter_Tritanopia();
+      case 3:
+        return const VisionFilter_Achromatopsia();
+      case 4:
+        return const VisionFilter_Tetrachromacy();
+      case 5:
+        return const VisionFilter_Myopia();
+      case 6:
+        return const VisionFilter_Hyperopia();
+      case 7:
+        return const VisionFilter_Presbyopia();
+      case 8:
+        var var_axisDeg = sse_decode_f_32(deserializer);
+        return VisionFilter_Astigmatism(axisDeg: var_axisDeg);
+      case 9:
+        var var_mode = sse_decode_vision_glaucoma_mode(deserializer);
+        return VisionFilter_Glaucoma(mode: var_mode);
+      case 10:
+        return const VisionFilter_MacularDegeneration();
+      case 11:
+        var var_side = sse_decode_f_32(deserializer);
+        return VisionFilter_Hemianopia(side: var_side);
+      case 12:
+        return const VisionFilter_TunnelVision();
+      case 13:
+        var var_seed = sse_decode_u_64(deserializer);
+        return VisionFilter_Cataract(seed: var_seed);
+      case 14:
+        var var_seed = sse_decode_u_64(deserializer);
+        var var_density = sse_decode_f_32(deserializer);
+        var var_size = sse_decode_f_32(deserializer);
+        var var_gazeX = sse_decode_f_32(deserializer);
+        var var_gazeY = sse_decode_f_32(deserializer);
+        return VisionFilter_Floaters(
+            seed: var_seed,
+            density: var_density,
+            size: var_size,
+            gazeX: var_gazeX,
+            gazeY: var_gazeY);
+      case 15:
+        return const VisionFilter_Photophobia();
+      case 16:
+        return const VisionFilter_NightBlindness();
+      case 17:
+        return const VisionFilter_Vertigo();
+      case 18:
+        return const VisionFilter_BppvRotation();
+      case 19:
+        return const VisionFilter_VestibularNeuritis();
+      case 20:
+        var var_offsetX = sse_decode_f_32(deserializer);
+        var var_offsetY = sse_decode_f_32(deserializer);
+        var var_ghostStrength = sse_decode_f_32(deserializer);
+        return VisionFilter_Diplopia(
+            offsetX: var_offsetX,
+            offsetY: var_offsetY,
+            ghostStrength: var_ghostStrength);
+      case 21:
+        var var_amplitude = sse_decode_f_32(deserializer);
+        var var_directionDeg = sse_decode_f_32(deserializer);
+        return VisionFilter_Nystagmus(
+            amplitude: var_amplitude, directionDeg: var_directionDeg);
+      case 22:
+        var var_numRays = sse_decode_u_32(deserializer);
+        var var_rayLengthRatio = sse_decode_f_32(deserializer);
+        var var_threshold = sse_decode_f_32(deserializer);
+        var var_dispersion = sse_decode_f_32(deserializer);
+        return VisionFilter_Starbursts(
+            numRays: var_numRays,
+            rayLengthRatio: var_rayLengthRatio,
+            threshold: var_threshold,
+            dispersion: var_dispersion);
+      case 23:
+        return const VisionFilter_EyeStrain();
+      case 24:
+        return const VisionFilter_DryEye();
+      case 25:
+        var var_freq = sse_decode_f_32(deserializer);
+        var var_seed = sse_decode_u_64(deserializer);
+        return VisionFilter_Metamorphopsia(freq: var_freq, seed: var_seed);
+      case 26:
+        return const VisionFilter_ContrastSensitivity();
+      case 27:
+        var var_cellSize = sse_decode_u_32(deserializer);
+        return VisionFilter_DetailLoss(cellSize: var_cellSize);
+      case 28:
+        return const VisionFilter_Teichopsia();
+      case 29:
+        var var_seed = sse_decode_u_64(deserializer);
+        return VisionFilter_FlickeringStars(seed: var_seed);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
+  VisionGlaucomaMode sse_decode_vision_glaucoma_mode(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
-    return VisionFilter.values[inner];
+    return VisionGlaucomaMode.values[inner];
   }
 
   @protected
@@ -412,7 +634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  int cst_encode_vision_filter(VisionFilter raw) {
+  int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_i_32(raw.index);
   }
@@ -421,6 +643,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_vision_filter(
+      VisionFilter self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_vision_filter(self, serializer);
   }
 
   @protected
@@ -494,6 +723,114 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case VisionFilter_Protanopia():
+        sse_encode_i_32(0, serializer);
+      case VisionFilter_Deuteranopia():
+        sse_encode_i_32(1, serializer);
+      case VisionFilter_Tritanopia():
+        sse_encode_i_32(2, serializer);
+      case VisionFilter_Achromatopsia():
+        sse_encode_i_32(3, serializer);
+      case VisionFilter_Tetrachromacy():
+        sse_encode_i_32(4, serializer);
+      case VisionFilter_Myopia():
+        sse_encode_i_32(5, serializer);
+      case VisionFilter_Hyperopia():
+        sse_encode_i_32(6, serializer);
+      case VisionFilter_Presbyopia():
+        sse_encode_i_32(7, serializer);
+      case VisionFilter_Astigmatism(axisDeg: final axisDeg):
+        sse_encode_i_32(8, serializer);
+        sse_encode_f_32(axisDeg, serializer);
+      case VisionFilter_Glaucoma(mode: final mode):
+        sse_encode_i_32(9, serializer);
+        sse_encode_vision_glaucoma_mode(mode, serializer);
+      case VisionFilter_MacularDegeneration():
+        sse_encode_i_32(10, serializer);
+      case VisionFilter_Hemianopia(side: final side):
+        sse_encode_i_32(11, serializer);
+        sse_encode_f_32(side, serializer);
+      case VisionFilter_TunnelVision():
+        sse_encode_i_32(12, serializer);
+      case VisionFilter_Cataract(seed: final seed):
+        sse_encode_i_32(13, serializer);
+        sse_encode_u_64(seed, serializer);
+      case VisionFilter_Floaters(
+          seed: final seed,
+          density: final density,
+          size: final size,
+          gazeX: final gazeX,
+          gazeY: final gazeY
+        ):
+        sse_encode_i_32(14, serializer);
+        sse_encode_u_64(seed, serializer);
+        sse_encode_f_32(density, serializer);
+        sse_encode_f_32(size, serializer);
+        sse_encode_f_32(gazeX, serializer);
+        sse_encode_f_32(gazeY, serializer);
+      case VisionFilter_Photophobia():
+        sse_encode_i_32(15, serializer);
+      case VisionFilter_NightBlindness():
+        sse_encode_i_32(16, serializer);
+      case VisionFilter_Vertigo():
+        sse_encode_i_32(17, serializer);
+      case VisionFilter_BppvRotation():
+        sse_encode_i_32(18, serializer);
+      case VisionFilter_VestibularNeuritis():
+        sse_encode_i_32(19, serializer);
+      case VisionFilter_Diplopia(
+          offsetX: final offsetX,
+          offsetY: final offsetY,
+          ghostStrength: final ghostStrength
+        ):
+        sse_encode_i_32(20, serializer);
+        sse_encode_f_32(offsetX, serializer);
+        sse_encode_f_32(offsetY, serializer);
+        sse_encode_f_32(ghostStrength, serializer);
+      case VisionFilter_Nystagmus(
+          amplitude: final amplitude,
+          directionDeg: final directionDeg
+        ):
+        sse_encode_i_32(21, serializer);
+        sse_encode_f_32(amplitude, serializer);
+        sse_encode_f_32(directionDeg, serializer);
+      case VisionFilter_Starbursts(
+          numRays: final numRays,
+          rayLengthRatio: final rayLengthRatio,
+          threshold: final threshold,
+          dispersion: final dispersion
+        ):
+        sse_encode_i_32(22, serializer);
+        sse_encode_u_32(numRays, serializer);
+        sse_encode_f_32(rayLengthRatio, serializer);
+        sse_encode_f_32(threshold, serializer);
+        sse_encode_f_32(dispersion, serializer);
+      case VisionFilter_EyeStrain():
+        sse_encode_i_32(23, serializer);
+      case VisionFilter_DryEye():
+        sse_encode_i_32(24, serializer);
+      case VisionFilter_Metamorphopsia(freq: final freq, seed: final seed):
+        sse_encode_i_32(25, serializer);
+        sse_encode_f_32(freq, serializer);
+        sse_encode_u_64(seed, serializer);
+      case VisionFilter_ContrastSensitivity():
+        sse_encode_i_32(26, serializer);
+      case VisionFilter_DetailLoss(cellSize: final cellSize):
+        sse_encode_i_32(27, serializer);
+        sse_encode_u_32(cellSize, serializer);
+      case VisionFilter_Teichopsia():
+        sse_encode_i_32(28, serializer);
+      case VisionFilter_FlickeringStars(seed: final seed):
+        sse_encode_i_32(29, serializer);
+        sse_encode_u_64(seed, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_vision_glaucoma_mode(
+      VisionGlaucomaMode self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
   }

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -22,6 +22,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
 
   @protected
@@ -55,7 +58,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   VisionFilter dco_decode_vision_filter(dynamic raw);
 
   @protected
+  VisionGlaucomaMode dco_decode_vision_glaucoma_mode(dynamic raw);
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
+
+  @protected
+  VisionFilter sse_decode_box_autoadd_vision_filter(
+      SseDeserializer deserializer);
 
   @protected
   double sse_decode_f_32(SseDeserializer deserializer);
@@ -91,12 +101,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   VisionFilter sse_decode_vision_filter(SseDeserializer deserializer);
 
   @protected
+  VisionGlaucomaMode sse_decode_vision_glaucoma_mode(
+      SseDeserializer deserializer);
+
+  @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
   ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_String(String raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_list_prim_u_8_strict(utf8.encoder.convert(raw));
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_vision_filter> cst_encode_box_autoadd_vision_filter(
+      VisionFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_vision_filter();
+    cst_api_fill_to_wire_vision_filter(raw, ptr.ref);
+    return ptr;
   }
 
   @protected
@@ -143,6 +166,181 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_vision_filter(
+      VisionFilter apiObj, ffi.Pointer<wire_cst_vision_filter> wireObj) {
+    cst_api_fill_to_wire_vision_filter(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_vision_filter(
+      VisionFilter apiObj, wire_cst_vision_filter wireObj) {
+    if (apiObj is VisionFilter_Protanopia) {
+      wireObj.tag = 0;
+      return;
+    }
+    if (apiObj is VisionFilter_Deuteranopia) {
+      wireObj.tag = 1;
+      return;
+    }
+    if (apiObj is VisionFilter_Tritanopia) {
+      wireObj.tag = 2;
+      return;
+    }
+    if (apiObj is VisionFilter_Achromatopsia) {
+      wireObj.tag = 3;
+      return;
+    }
+    if (apiObj is VisionFilter_Tetrachromacy) {
+      wireObj.tag = 4;
+      return;
+    }
+    if (apiObj is VisionFilter_Myopia) {
+      wireObj.tag = 5;
+      return;
+    }
+    if (apiObj is VisionFilter_Hyperopia) {
+      wireObj.tag = 6;
+      return;
+    }
+    if (apiObj is VisionFilter_Presbyopia) {
+      wireObj.tag = 7;
+      return;
+    }
+    if (apiObj is VisionFilter_Astigmatism) {
+      var pre_axis_deg = cst_encode_f_32(apiObj.axisDeg);
+      wireObj.tag = 8;
+      wireObj.kind.Astigmatism.axis_deg = pre_axis_deg;
+      return;
+    }
+    if (apiObj is VisionFilter_Glaucoma) {
+      var pre_mode = cst_encode_vision_glaucoma_mode(apiObj.mode);
+      wireObj.tag = 9;
+      wireObj.kind.Glaucoma.mode = pre_mode;
+      return;
+    }
+    if (apiObj is VisionFilter_MacularDegeneration) {
+      wireObj.tag = 10;
+      return;
+    }
+    if (apiObj is VisionFilter_Hemianopia) {
+      var pre_side = cst_encode_f_32(apiObj.side);
+      wireObj.tag = 11;
+      wireObj.kind.Hemianopia.side = pre_side;
+      return;
+    }
+    if (apiObj is VisionFilter_TunnelVision) {
+      wireObj.tag = 12;
+      return;
+    }
+    if (apiObj is VisionFilter_Cataract) {
+      var pre_seed = cst_encode_u_64(apiObj.seed);
+      wireObj.tag = 13;
+      wireObj.kind.Cataract.seed = pre_seed;
+      return;
+    }
+    if (apiObj is VisionFilter_Floaters) {
+      var pre_seed = cst_encode_u_64(apiObj.seed);
+      var pre_density = cst_encode_f_32(apiObj.density);
+      var pre_size = cst_encode_f_32(apiObj.size);
+      var pre_gaze_x = cst_encode_f_32(apiObj.gazeX);
+      var pre_gaze_y = cst_encode_f_32(apiObj.gazeY);
+      wireObj.tag = 14;
+      wireObj.kind.Floaters.seed = pre_seed;
+      wireObj.kind.Floaters.density = pre_density;
+      wireObj.kind.Floaters.size = pre_size;
+      wireObj.kind.Floaters.gaze_x = pre_gaze_x;
+      wireObj.kind.Floaters.gaze_y = pre_gaze_y;
+      return;
+    }
+    if (apiObj is VisionFilter_Photophobia) {
+      wireObj.tag = 15;
+      return;
+    }
+    if (apiObj is VisionFilter_NightBlindness) {
+      wireObj.tag = 16;
+      return;
+    }
+    if (apiObj is VisionFilter_Vertigo) {
+      wireObj.tag = 17;
+      return;
+    }
+    if (apiObj is VisionFilter_BppvRotation) {
+      wireObj.tag = 18;
+      return;
+    }
+    if (apiObj is VisionFilter_VestibularNeuritis) {
+      wireObj.tag = 19;
+      return;
+    }
+    if (apiObj is VisionFilter_Diplopia) {
+      var pre_offset_x = cst_encode_f_32(apiObj.offsetX);
+      var pre_offset_y = cst_encode_f_32(apiObj.offsetY);
+      var pre_ghost_strength = cst_encode_f_32(apiObj.ghostStrength);
+      wireObj.tag = 20;
+      wireObj.kind.Diplopia.offset_x = pre_offset_x;
+      wireObj.kind.Diplopia.offset_y = pre_offset_y;
+      wireObj.kind.Diplopia.ghost_strength = pre_ghost_strength;
+      return;
+    }
+    if (apiObj is VisionFilter_Nystagmus) {
+      var pre_amplitude = cst_encode_f_32(apiObj.amplitude);
+      var pre_direction_deg = cst_encode_f_32(apiObj.directionDeg);
+      wireObj.tag = 21;
+      wireObj.kind.Nystagmus.amplitude = pre_amplitude;
+      wireObj.kind.Nystagmus.direction_deg = pre_direction_deg;
+      return;
+    }
+    if (apiObj is VisionFilter_Starbursts) {
+      var pre_num_rays = cst_encode_u_32(apiObj.numRays);
+      var pre_ray_length_ratio = cst_encode_f_32(apiObj.rayLengthRatio);
+      var pre_threshold = cst_encode_f_32(apiObj.threshold);
+      var pre_dispersion = cst_encode_f_32(apiObj.dispersion);
+      wireObj.tag = 22;
+      wireObj.kind.Starbursts.num_rays = pre_num_rays;
+      wireObj.kind.Starbursts.ray_length_ratio = pre_ray_length_ratio;
+      wireObj.kind.Starbursts.threshold = pre_threshold;
+      wireObj.kind.Starbursts.dispersion = pre_dispersion;
+      return;
+    }
+    if (apiObj is VisionFilter_EyeStrain) {
+      wireObj.tag = 23;
+      return;
+    }
+    if (apiObj is VisionFilter_DryEye) {
+      wireObj.tag = 24;
+      return;
+    }
+    if (apiObj is VisionFilter_Metamorphopsia) {
+      var pre_freq = cst_encode_f_32(apiObj.freq);
+      var pre_seed = cst_encode_u_64(apiObj.seed);
+      wireObj.tag = 25;
+      wireObj.kind.Metamorphopsia.freq = pre_freq;
+      wireObj.kind.Metamorphopsia.seed = pre_seed;
+      return;
+    }
+    if (apiObj is VisionFilter_ContrastSensitivity) {
+      wireObj.tag = 26;
+      return;
+    }
+    if (apiObj is VisionFilter_DetailLoss) {
+      var pre_cell_size = cst_encode_u_32(apiObj.cellSize);
+      wireObj.tag = 27;
+      wireObj.kind.DetailLoss.cell_size = pre_cell_size;
+      return;
+    }
+    if (apiObj is VisionFilter_Teichopsia) {
+      wireObj.tag = 28;
+      return;
+    }
+    if (apiObj is VisionFilter_FlickeringStars) {
+      var pre_seed = cst_encode_u_64(apiObj.seed);
+      wireObj.tag = 29;
+      wireObj.kind.FlickeringStars.seed = pre_seed;
+      return;
+    }
+  }
+
+  @protected
   double cst_encode_f_32(double raw);
 
   @protected
@@ -158,10 +356,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_encode_unit(void raw);
 
   @protected
-  int cst_encode_vision_filter(VisionFilter raw);
+  int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_vision_filter(
+      VisionFilter self, SseSerializer serializer);
 
   @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
@@ -197,6 +399,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_vision_glaucoma_mode(
+      VisionGlaucomaMode self, SseSerializer serializer);
 
   @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
@@ -240,7 +446,7 @@ class RustLibWire implements BaseWire {
       .asFunction<void Function(DartPostCObjectFnType)>();
 
   WireSyncRust2DartDco wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
-    int filter,
+    ffi.Pointer<wire_cst_vision_filter> filter,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> rgba8,
     int width,
     int height,
@@ -259,7 +465,7 @@ class RustLibWire implements BaseWire {
       _lookup<
           ffi.NativeFunction<
               WireSyncRust2DartDco Function(
-                ffi.Int32,
+                ffi.Pointer<wire_cst_vision_filter>,
                 ffi.Pointer<wire_cst_list_prim_u_8_loose>,
                 ffi.Uint32,
                 ffi.Uint32,
@@ -270,7 +476,7 @@ class RustLibWire implements BaseWire {
   late final _wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8 =
       _wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8Ptr.asFunction<
           WireSyncRust2DartDco Function(
-            int,
+            ffi.Pointer<wire_cst_vision_filter>,
             ffi.Pointer<wire_cst_list_prim_u_8_loose>,
             int,
             int,
@@ -278,63 +484,84 @@ class RustLibWire implements BaseWire {
           )>();
 
   WireSyncRust2DartDco wire__crate__api__sensus_bridge__vision_shader_glsl(
-    int filter,
+    ffi.Pointer<wire_cst_vision_filter> filter,
   ) {
     return _wire__crate__api__sensus_bridge__vision_shader_glsl(filter);
   }
 
-  late final _wire__crate__api__sensus_bridge__vision_shader_glslPtr =
-      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Int32)>>(
+  late final _wire__crate__api__sensus_bridge__vision_shader_glslPtr = _lookup<
+      ffi.NativeFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_vision_filter>)>>(
     'frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_shader_glsl',
   );
   late final _wire__crate__api__sensus_bridge__vision_shader_glsl =
-      _wire__crate__api__sensus_bridge__vision_shader_glslPtr
-          .asFunction<WireSyncRust2DartDco Function(int)>();
+      _wire__crate__api__sensus_bridge__vision_shader_glslPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_vision_filter>)>();
 
   WireSyncRust2DartDco wire__crate__api__sensus_bridge__vision_uniform_layout(
-    int filter,
+    ffi.Pointer<wire_cst_vision_filter> filter,
   ) {
     return _wire__crate__api__sensus_bridge__vision_uniform_layout(filter);
   }
 
   late final _wire__crate__api__sensus_bridge__vision_uniform_layoutPtr =
-      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function(ffi.Int32)>>(
+      _lookup<
+          ffi.NativeFunction<
+              WireSyncRust2DartDco Function(
+                  ffi.Pointer<wire_cst_vision_filter>)>>(
     'frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_uniform_layout',
   );
   late final _wire__crate__api__sensus_bridge__vision_uniform_layout =
-      _wire__crate__api__sensus_bridge__vision_uniform_layoutPtr
-          .asFunction<WireSyncRust2DartDco Function(int)>();
+      _wire__crate__api__sensus_bridge__vision_uniform_layoutPtr.asFunction<
+          WireSyncRust2DartDco Function(ffi.Pointer<wire_cst_vision_filter>)>();
 
   WireSyncRust2DartDco wire__crate__api__sensus_bridge__vision_uniforms(
-    int filter,
+    ffi.Pointer<wire_cst_vision_filter> filter,
     double strength,
+    double time,
     int width,
     int height,
-    int _seed,
   ) {
     return _wire__crate__api__sensus_bridge__vision_uniforms(
       filter,
       strength,
+      time,
       width,
       height,
-      _seed,
     );
   }
 
   late final _wire__crate__api__sensus_bridge__vision_uniformsPtr = _lookup<
       ffi.NativeFunction<
           WireSyncRust2DartDco Function(
-            ffi.Int32,
+            ffi.Pointer<wire_cst_vision_filter>,
+            ffi.Float,
             ffi.Float,
             ffi.Uint32,
             ffi.Uint32,
-            ffi.Uint64,
           )>>(
     'frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_uniforms',
   );
   late final _wire__crate__api__sensus_bridge__vision_uniforms =
       _wire__crate__api__sensus_bridge__vision_uniformsPtr.asFunction<
-          WireSyncRust2DartDco Function(int, double, int, int, int)>();
+          WireSyncRust2DartDco Function(
+            ffi.Pointer<wire_cst_vision_filter>,
+            double,
+            double,
+            int,
+            int,
+          )>();
+
+  ffi.Pointer<wire_cst_vision_filter> cst_new_box_autoadd_vision_filter() {
+    return _cst_new_box_autoadd_vision_filter();
+  }
+
+  late final _cst_new_box_autoadd_vision_filterPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_cst_vision_filter> Function()>>(
+      'frbgen_universal_experience_cst_new_box_autoadd_vision_filter');
+  late final _cst_new_box_autoadd_vision_filter =
+      _cst_new_box_autoadd_vision_filterPtr
+          .asFunction<ffi.Pointer<wire_cst_vision_filter> Function()>();
 
   ffi.Pointer<wire_cst_list_String> cst_new_list_String(int len) {
     return _cst_new_list_String(len);
@@ -406,6 +633,125 @@ typedef DartDartPostCObjectFnTypeFunction = bool Function(
     DartDartPort port_id, ffi.Pointer<ffi.Void> message);
 typedef DartPostCObjectFnType
     = ffi.Pointer<ffi.NativeFunction<DartPostCObjectFnTypeFunction>>;
+
+final class wire_cst_VisionFilter_Astigmatism extends ffi.Struct {
+  @ffi.Float()
+  external double axis_deg;
+}
+
+final class wire_cst_VisionFilter_Glaucoma extends ffi.Struct {
+  @ffi.Int32()
+  external int mode;
+}
+
+final class wire_cst_VisionFilter_Hemianopia extends ffi.Struct {
+  @ffi.Float()
+  external double side;
+}
+
+final class wire_cst_VisionFilter_Cataract extends ffi.Struct {
+  @ffi.Uint64()
+  external int seed;
+}
+
+final class wire_cst_VisionFilter_Floaters extends ffi.Struct {
+  @ffi.Uint64()
+  external int seed;
+
+  @ffi.Float()
+  external double density;
+
+  @ffi.Float()
+  external double size;
+
+  @ffi.Float()
+  external double gaze_x;
+
+  @ffi.Float()
+  external double gaze_y;
+}
+
+final class wire_cst_VisionFilter_Diplopia extends ffi.Struct {
+  @ffi.Float()
+  external double offset_x;
+
+  @ffi.Float()
+  external double offset_y;
+
+  @ffi.Float()
+  external double ghost_strength;
+}
+
+final class wire_cst_VisionFilter_Nystagmus extends ffi.Struct {
+  @ffi.Float()
+  external double amplitude;
+
+  @ffi.Float()
+  external double direction_deg;
+}
+
+final class wire_cst_VisionFilter_Starbursts extends ffi.Struct {
+  @ffi.Uint32()
+  external int num_rays;
+
+  @ffi.Float()
+  external double ray_length_ratio;
+
+  @ffi.Float()
+  external double threshold;
+
+  @ffi.Float()
+  external double dispersion;
+}
+
+final class wire_cst_VisionFilter_Metamorphopsia extends ffi.Struct {
+  @ffi.Float()
+  external double freq;
+
+  @ffi.Uint64()
+  external int seed;
+}
+
+final class wire_cst_VisionFilter_DetailLoss extends ffi.Struct {
+  @ffi.Uint32()
+  external int cell_size;
+}
+
+final class wire_cst_VisionFilter_FlickeringStars extends ffi.Struct {
+  @ffi.Uint64()
+  external int seed;
+}
+
+final class VisionFilterKind extends ffi.Union {
+  external wire_cst_VisionFilter_Astigmatism Astigmatism;
+
+  external wire_cst_VisionFilter_Glaucoma Glaucoma;
+
+  external wire_cst_VisionFilter_Hemianopia Hemianopia;
+
+  external wire_cst_VisionFilter_Cataract Cataract;
+
+  external wire_cst_VisionFilter_Floaters Floaters;
+
+  external wire_cst_VisionFilter_Diplopia Diplopia;
+
+  external wire_cst_VisionFilter_Nystagmus Nystagmus;
+
+  external wire_cst_VisionFilter_Starbursts Starbursts;
+
+  external wire_cst_VisionFilter_Metamorphopsia Metamorphopsia;
+
+  external wire_cst_VisionFilter_DetailLoss DetailLoss;
+
+  external wire_cst_VisionFilter_FlickeringStars FlickeringStars;
+}
+
+final class wire_cst_vision_filter extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external VisionFilterKind kind;
+}
 
 final class wire_cst_list_prim_u_8_loose extends ffi.Struct {
   external ffi.Pointer<ffi.Uint8> ptr;

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -3,7 +3,6 @@
 
 // ignore_for_file: unused_import, unused_element, unnecessary_import, duplicate_ignore, invalid_use_of_internal_member, annotate_overrides, non_constant_identifier_names, curly_braces_in_flow_control_structures, prefer_const_literals_to_create_immutables, unused_field
 
-
 // Static analysis wrongly picks the IO variant, thus ignore this
 // ignore_for_file: argument_type_not_assignable
 
@@ -13,150 +12,378 @@ import 'dart:convert';
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated_web.dart';
 
+abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
+  RustLibApiImplPlatform({
+    required super.handler,
+    required super.wire,
+    required super.generalizedFrbRustBinding,
+    required super.portManager,
+  });
 
+  @protected
+  String dco_decode_String(dynamic raw);
 
+  @protected
+  VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw);
 
-                abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
-                  RustLibApiImplPlatform({
-                    required super.handler,
-                    required super.wire,
-                    required super.generalizedFrbRustBinding,
-                    required super.portManager,
-                  });
+  @protected
+  double dco_decode_f_32(dynamic raw);
 
-                  
+  @protected
+  int dco_decode_i_32(dynamic raw);
 
-                  @protected String dco_decode_String(dynamic raw);
+  @protected
+  List<String> dco_decode_list_String(dynamic raw);
 
-@protected double dco_decode_f_32(dynamic raw);
+  @protected
+  Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
 
-@protected int dco_decode_i_32(dynamic raw);
+  @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
 
-@protected List<String> dco_decode_list_String(dynamic raw);
+  @protected
+  Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
-@protected Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
+  @protected
+  int dco_decode_u_32(dynamic raw);
 
-@protected List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+  @protected
+  BigInt dco_decode_u_64(dynamic raw);
 
-@protected Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+  @protected
+  int dco_decode_u_8(dynamic raw);
 
-@protected int dco_decode_u_32(dynamic raw);
+  @protected
+  void dco_decode_unit(dynamic raw);
 
-@protected BigInt dco_decode_u_64(dynamic raw);
+  @protected
+  VisionFilter dco_decode_vision_filter(dynamic raw);
 
-@protected int dco_decode_u_8(dynamic raw);
+  @protected
+  VisionGlaucomaMode dco_decode_vision_glaucoma_mode(dynamic raw);
 
-@protected void dco_decode_unit(dynamic raw);
+  @protected
+  String sse_decode_String(SseDeserializer deserializer);
 
-@protected VisionFilter dco_decode_vision_filter(dynamic raw);
+  @protected
+  VisionFilter sse_decode_box_autoadd_vision_filter(
+      SseDeserializer deserializer);
 
-@protected String sse_decode_String(SseDeserializer deserializer);
+  @protected
+  double sse_decode_f_32(SseDeserializer deserializer);
 
-@protected double sse_decode_f_32(SseDeserializer deserializer);
+  @protected
+  int sse_decode_i_32(SseDeserializer deserializer);
 
-@protected int sse_decode_i_32(SseDeserializer deserializer);
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
 
-@protected List<String> sse_decode_list_String(SseDeserializer deserializer);
+  @protected
+  Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
 
-@protected Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
 
-@protected List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
+  @protected
+  Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
-@protected Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_32(SseDeserializer deserializer);
 
-@protected int sse_decode_u_32(SseDeserializer deserializer);
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer);
 
-@protected BigInt sse_decode_u_64(SseDeserializer deserializer);
+  @protected
+  int sse_decode_u_8(SseDeserializer deserializer);
 
-@protected int sse_decode_u_8(SseDeserializer deserializer);
+  @protected
+  void sse_decode_unit(SseDeserializer deserializer);
 
-@protected void sse_decode_unit(SseDeserializer deserializer);
+  @protected
+  VisionFilter sse_decode_vision_filter(SseDeserializer deserializer);
 
-@protected VisionFilter sse_decode_vision_filter(SseDeserializer deserializer);
+  @protected
+  VisionGlaucomaMode sse_decode_vision_glaucoma_mode(
+      SseDeserializer deserializer);
 
-@protected bool sse_decode_bool(SseDeserializer deserializer);
+  @protected
+  bool sse_decode_bool(SseDeserializer deserializer);
 
-@protected String cst_encode_String(String raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return raw; }
+  @protected
+  String cst_encode_String(String raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
 
-@protected JSAny cst_encode_list_String(List<String> raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return raw.map(cst_encode_String).toList().jsify()!; }
+  @protected
+  JSAny cst_encode_box_autoadd_vision_filter(VisionFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_vision_filter(raw);
+  }
 
-@protected JSAny cst_encode_list_prim_f_32_strict(Float32List raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return raw.jsify()!; }
+  @protected
+  JSAny cst_encode_list_String(List<String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_String).toList().jsify()!;
+  }
 
-@protected JSAny cst_encode_list_prim_u_8_loose(List<int> raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return raw.jsify()!; }
+  @protected
+  JSAny cst_encode_list_prim_f_32_strict(Float32List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.jsify()!;
+  }
 
-@protected JSAny cst_encode_list_prim_u_8_strict(Uint8List raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return raw.jsify()!; }
+  @protected
+  JSAny cst_encode_list_prim_u_8_loose(List<int> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.jsify()!;
+  }
 
-@protected JSAny cst_encode_u_64(BigInt raw){ // Codec=Cst (C-struct based), see doc to use other codecs
-return castNativeBigInt(raw); }
+  @protected
+  JSAny cst_encode_list_prim_u_8_strict(Uint8List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.jsify()!;
+  }
 
-@protected double cst_encode_f_32(double raw);
+  @protected
+  JSAny cst_encode_u_64(BigInt raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return castNativeBigInt(raw);
+  }
 
-@protected int cst_encode_i_32(int raw);
+  @protected
+  JSAny cst_encode_vision_filter(VisionFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    if (raw is VisionFilter_Protanopia) {
+      return [0].jsify()!;
+    }
+    if (raw is VisionFilter_Deuteranopia) {
+      return [1].jsify()!;
+    }
+    if (raw is VisionFilter_Tritanopia) {
+      return [2].jsify()!;
+    }
+    if (raw is VisionFilter_Achromatopsia) {
+      return [3].jsify()!;
+    }
+    if (raw is VisionFilter_Tetrachromacy) {
+      return [4].jsify()!;
+    }
+    if (raw is VisionFilter_Myopia) {
+      return [5].jsify()!;
+    }
+    if (raw is VisionFilter_Hyperopia) {
+      return [6].jsify()!;
+    }
+    if (raw is VisionFilter_Presbyopia) {
+      return [7].jsify()!;
+    }
+    if (raw is VisionFilter_Astigmatism) {
+      return [8, cst_encode_f_32(raw.axisDeg)].jsify()!;
+    }
+    if (raw is VisionFilter_Glaucoma) {
+      return [9, cst_encode_vision_glaucoma_mode(raw.mode)].jsify()!;
+    }
+    if (raw is VisionFilter_MacularDegeneration) {
+      return [10].jsify()!;
+    }
+    if (raw is VisionFilter_Hemianopia) {
+      return [11, cst_encode_f_32(raw.side)].jsify()!;
+    }
+    if (raw is VisionFilter_TunnelVision) {
+      return [12].jsify()!;
+    }
+    if (raw is VisionFilter_Cataract) {
+      return [13, cst_encode_u_64(raw.seed)].jsify()!;
+    }
+    if (raw is VisionFilter_Floaters) {
+      return [
+        14,
+        cst_encode_u_64(raw.seed),
+        cst_encode_f_32(raw.density),
+        cst_encode_f_32(raw.size),
+        cst_encode_f_32(raw.gazeX),
+        cst_encode_f_32(raw.gazeY)
+      ].jsify()!;
+    }
+    if (raw is VisionFilter_Photophobia) {
+      return [15].jsify()!;
+    }
+    if (raw is VisionFilter_NightBlindness) {
+      return [16].jsify()!;
+    }
+    if (raw is VisionFilter_Vertigo) {
+      return [17].jsify()!;
+    }
+    if (raw is VisionFilter_BppvRotation) {
+      return [18].jsify()!;
+    }
+    if (raw is VisionFilter_VestibularNeuritis) {
+      return [19].jsify()!;
+    }
+    if (raw is VisionFilter_Diplopia) {
+      return [
+        20,
+        cst_encode_f_32(raw.offsetX),
+        cst_encode_f_32(raw.offsetY),
+        cst_encode_f_32(raw.ghostStrength)
+      ].jsify()!;
+    }
+    if (raw is VisionFilter_Nystagmus) {
+      return [
+        21,
+        cst_encode_f_32(raw.amplitude),
+        cst_encode_f_32(raw.directionDeg)
+      ].jsify()!;
+    }
+    if (raw is VisionFilter_Starbursts) {
+      return [
+        22,
+        cst_encode_u_32(raw.numRays),
+        cst_encode_f_32(raw.rayLengthRatio),
+        cst_encode_f_32(raw.threshold),
+        cst_encode_f_32(raw.dispersion)
+      ].jsify()!;
+    }
+    if (raw is VisionFilter_EyeStrain) {
+      return [23].jsify()!;
+    }
+    if (raw is VisionFilter_DryEye) {
+      return [24].jsify()!;
+    }
+    if (raw is VisionFilter_Metamorphopsia) {
+      return [25, cst_encode_f_32(raw.freq), cst_encode_u_64(raw.seed)]
+          .jsify()!;
+    }
+    if (raw is VisionFilter_ContrastSensitivity) {
+      return [26].jsify()!;
+    }
+    if (raw is VisionFilter_DetailLoss) {
+      return [27, cst_encode_u_32(raw.cellSize)].jsify()!;
+    }
+    if (raw is VisionFilter_Teichopsia) {
+      return [28].jsify()!;
+    }
+    if (raw is VisionFilter_FlickeringStars) {
+      return [29, cst_encode_u_64(raw.seed)].jsify()!;
+    }
 
-@protected int cst_encode_u_32(int raw);
+    throw Exception('unreachable');
+  }
 
-@protected int cst_encode_u_8(int raw);
+  @protected
+  double cst_encode_f_32(double raw);
 
-@protected void cst_encode_unit(void raw);
+  @protected
+  int cst_encode_i_32(int raw);
 
-@protected int cst_encode_vision_filter(VisionFilter raw);
+  @protected
+  int cst_encode_u_32(int raw);
 
-@protected void sse_encode_String(String self, SseSerializer serializer);
+  @protected
+  int cst_encode_u_8(int raw);
 
-@protected void sse_encode_f_32(double self, SseSerializer serializer);
+  @protected
+  void cst_encode_unit(void raw);
 
-@protected void sse_encode_i_32(int self, SseSerializer serializer);
+  @protected
+  int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw);
 
-@protected void sse_encode_list_String(List<String> self, SseSerializer serializer);
+  @protected
+  void sse_encode_String(String self, SseSerializer serializer);
 
-@protected void sse_encode_list_prim_f_32_strict(Float32List self, SseSerializer serializer);
+  @protected
+  void sse_encode_box_autoadd_vision_filter(
+      VisionFilter self, SseSerializer serializer);
 
-@protected void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
+  @protected
+  void sse_encode_f_32(double self, SseSerializer serializer);
 
-@protected void sse_encode_list_prim_u_8_strict(Uint8List self, SseSerializer serializer);
+  @protected
+  void sse_encode_i_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_u_32(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
 
-@protected void sse_encode_u_64(BigInt self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_prim_f_32_strict(
+      Float32List self, SseSerializer serializer);
 
-@protected void sse_encode_u_8(int self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
 
-@protected void sse_encode_unit(void self, SseSerializer serializer);
+  @protected
+  void sse_encode_list_prim_u_8_strict(
+      Uint8List self, SseSerializer serializer);
 
-@protected void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer);
+  @protected
+  void sse_encode_u_32(int self, SseSerializer serializer);
 
-@protected void sse_encode_bool(bool self, SseSerializer serializer);
-                }
-                
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer);
 
+  @protected
+  void sse_encode_u_8(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_vision_glaucoma_mode(
+      VisionGlaucomaMode self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_bool(bool self, SseSerializer serializer);
+}
 
 // Section: wire_class
 
 class RustLibWire implements BaseWire {
-            RustLibWire.fromExternalLibrary(ExternalLibrary lib);
+  RustLibWire.fromExternalLibrary(ExternalLibrary lib);
 
-            JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(int filter,JSAny rgba8,int width,int height,double strength) => wasmModule.wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(filter,rgba8,width,height,strength);
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(JSAny filter,
+              JSAny rgba8, int width, int height, double strength) =>
+          wasmModule.wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
+              filter, rgba8, width, height, strength);
 
-JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_shader_glsl(int filter) => wasmModule.wire__crate__api__sensus_bridge__vision_shader_glsl(filter);
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_shader_glsl(JSAny filter) =>
+          wasmModule
+              .wire__crate__api__sensus_bridge__vision_shader_glsl(filter);
 
-JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_uniform_layout(int filter) => wasmModule.wire__crate__api__sensus_bridge__vision_uniform_layout(filter);
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_uniform_layout(JSAny filter) =>
+          wasmModule
+              .wire__crate__api__sensus_bridge__vision_uniform_layout(filter);
 
-JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_uniforms(int filter,double strength,int width,int height,JSAny seed) => wasmModule.wire__crate__api__sensus_bridge__vision_uniforms(filter,strength,width,height,seed);
-        }
-        @JS('wasm_bindgen') external RustLibWasmModule get wasmModule;
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_uniforms(JSAny filter,
+              double strength, double time, int width, int height) =>
+          wasmModule.wire__crate__api__sensus_bridge__vision_uniforms(
+              filter, strength, time, width, height);
+}
 
-        @JS() @anonymous extension type RustLibWasmModule._(JSObject _) implements JSObject {
-            external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(int filter,JSAny rgba8,int width,int height,double strength);
+@JS('wasm_bindgen')
+external RustLibWasmModule get wasmModule;
 
-external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_shader_glsl(int filter);
+@JS()
+@anonymous
+extension type RustLibWasmModule._(JSObject _) implements JSObject {
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
+          JSAny filter, JSAny rgba8, int width, int height, double strength);
 
-external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_uniform_layout(int filter);
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_shader_glsl(JSAny filter);
 
-external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */ wire__crate__api__sensus_bridge__vision_uniforms(int filter,double strength,int width,int height,JSAny _seed);
-        }
-        
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_uniform_layout(JSAny filter);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__vision_uniforms(
+          JSAny filter, double strength, double time, int width, int height);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "85.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "7.7.1"
   args:
     dependency: transitive
     description:
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -49,6 +57,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.12.6"
   characters:
     dependency: transitive
     description:
@@ -57,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -81,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.1"
   collection:
     dependency: transitive
     description:
@@ -124,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -160,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -199,6 +287,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed:
+    dependency: "direct dev"
+    description:
+      name: freezed
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.8"
+  freezed_annotation:
+    dependency: "direct main"
+    description:
+      name: freezed_annotation
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.4"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -207,6 +319,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   hooks:
     dependency: transitive
     description:
@@ -223,6 +343,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
@@ -231,6 +359,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   jni:
     dependency: transitive
     description:
@@ -247,6 +383,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -319,6 +471,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -439,6 +599,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
   provider:
     dependency: "direct main"
     description:
@@ -455,6 +623,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
@@ -527,6 +703,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   shortid:
     dependency: transitive
     description:
@@ -540,6 +732,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
@@ -564,6 +764,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -588,6 +796,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   tray_manager:
     dependency: "direct main"
     description:
@@ -660,6 +876,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   window_manager:
     dependency: "direct main"
     description:
@@ -701,5 +933,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # codegen ツール (2.11.1) と生成物のバージョンスタンプを一致させるため exact pin。
   # （^ にすると 2.12.0 が入り forceSameCodegenVersion で実機初期化に失敗しうる）
   flutter_rust_bridge: 2.11.1
+  # FRB 2.11.1 は freezed 2.x 系を前提（3.x prerelease は非互換）。
+  freezed_annotation: ^2.4.4
 
 dev_dependencies:
   flutter_test:
@@ -41,6 +43,8 @@ dev_dependencies:
   flutter_lints: ^3.0.1
   # flutter_rust_bridge_codegen が生成時に要求する。
   ffigen: ^20.1.1
+  freezed: ^2.5.7
+  build_runner: ^2.4.13
 
 flutter:
   uses-material-design: true

--- a/rust/src/api/sensus_bridge.rs
+++ b/rust/src/api/sensus_bridge.rs
@@ -12,19 +12,58 @@
 //!
 //! アルゴリズム（行列値・半径式・色係数）は一切ここで持たない。すべて
 //! `sensus_core::shaders` の戻り値をそのまま展開するだけにして、正本を一元化する。
+//!
+//! # u32 / uint シードと count の扱い
+//!
+//! flat 配列の要素はすべて `f32`。`cataract` / `floaters` / `metamorphopsia` /
+//! `flickering_stars` の `uSeed`（GLSL では `uint`）や `uCount`（`int`）も f32 に
+//! 詰める。FragmentProgram には float uniform しか積まないため、Dart 側で
+//! `setFloat(i, value)` した後、シェーダの `uint`/`int` uniform へは Flutter の
+//! sampler/float bridge 経由で渡らない点に注意（これらの整数 uniform を使う実描画は
+//! #11 の GPU パスで個別に詰める）。本ブリッジが保証するのは「値そのもの」と
+//! 「レイアウト（順序）」であり、float の bit 精度は u32 が 2^24 を超えると失われる。
+//! seed は基本 0..少数を想定するため実害はないが、層を超える際の前提として明記する。
 
 use sensus_core::shaders;
 
-/// Dart 側で扱う vision フィルタ（MVP サブセット）。
+/// 緑内障の暗点モード。`sensus_core::vision::GlaucomaMode` の FRB 公開ミラー。
 ///
-/// sensus_core::Filter のうち、本 Issue (#7, sensus 連携 1/3) でブリッジを
-/// 通すものだけを列挙する。MVP は色覚 4 種 + 解像度依存の 2 例。全フィルタ網羅は
-/// 後続フェーズで `sensus_core::Filter` 全バリアントへ拡張する。
+/// FRB は外部クレートの enum を直接 Dart へ出せないため、ue 側で同型を定義して
+/// [`to_sensus`](VisionGlaucomaMode::to_sensus) で変換する。値は
+/// `glaucoma.frag` の `uMode`（0..3）に 1 対 1 対応する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisionGlaucomaMode {
+    /// 中心保存 + 周辺 smoothstep vignetting（既定）。uMode=0。
+    Vignette,
+    /// 上方弧状暗点（Bjerrum 上方）。uMode=1。
+    ArcuateSuperior,
+    /// 下方弧状暗点（Bjerrum 下方）。uMode=2。
+    ArcuateInferior,
+    /// 両弧状暗点（進行例）。uMode=3。
+    Biarcuate,
+}
+
+impl VisionGlaucomaMode {
+    fn to_sensus(self) -> sensus_core::vision::GlaucomaMode {
+        use sensus_core::vision::GlaucomaMode as G;
+        match self {
+            VisionGlaucomaMode::Vignette => G::Vignette,
+            VisionGlaucomaMode::ArcuateSuperior => G::ArcuateSuperior,
+            VisionGlaucomaMode::ArcuateInferior => G::ArcuateInferior,
+            VisionGlaucomaMode::Biarcuate => G::Biarcuate,
+        }
+    }
+}
+
+/// Dart 側で扱う vision フィルタ。`sensus_core::Filter` の vision バリアント全種を
+/// 網羅する。payload を持つフィルタは Rust enum のフィールド付きバリアントにして
+/// あり、FRB が Dart の sealed class 風コードを生成する。
 ///
-/// パラメータは MVP では `strength` 中心とし、解像度依存フィルタは
-/// [`vision_uniforms`] へ `width`/`height` を、ランダム系は `seed` を渡す。
+/// uniform レイアウトは各 `.frag` の uniform 宣言順（`sampler2D` を除く）に
+/// 厳密一致させる。詳細は [`vision_uniforms`] と [`vision_uniform_layout`] を参照。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VisionFilter {
+    // --- 色覚 (CVD) ---
     /// 1型2色覚（赤）。uniform: uStrength + uMatrix[9]。
     Protanopia,
     /// 2型2色覚（緑）。uniform: uStrength + uMatrix[9]。
@@ -33,10 +72,168 @@ pub enum VisionFilter {
     Tritanopia,
     /// 全色盲。uniform: uStrength + RGB luma weights。
     Achromatopsia,
-    /// 近視（解像度依存の disk blur）。uniform: uStrength + uRadiusPx + uTexelSize。
+    /// 四色型色覚。uniform: uStrength。
+    Tetrachromacy,
+
+    // --- 焦点 / 屈折 ---
+    /// 近視（解像度依存の disk blur）。
     Myopia,
-    /// 羞明（解像度依存の bloom）。uniform: uRadiusPx + uTexelSize（uStrength なし）。
+    /// 遠視（disk blur）。
+    Hyperopia,
+    /// 老視（disk blur）。
+    Presbyopia,
+    /// 乱視。`axis_deg`: シャープ方向の経線角（度数法、医学慣習）。
+    Astigmatism { axis_deg: f32 },
+
+    // --- 視野 ---
+    /// 緑内障。`mode`: 暗点モード。
+    Glaucoma { mode: VisionGlaucomaMode },
+    /// 加齢黄斑変性。
+    MacularDegeneration,
+    /// 半盲。`side`: 0.0 = 左視野消失, 1.0 = 右視野消失。
+    Hemianopia { side: f32 },
+    /// 視野狭窄（トンネル視）。
+    TunnelVision,
+
+    // --- 光 / 透明度 ---
+    /// 白内障。`seed`: 散乱グレア生成シード。
+    Cataract { seed: u64 },
+    /// 飛蚊症。`seed`/`density`/`size`/`gaze_x`/`gaze_y`。
+    Floaters {
+        seed: u64,
+        density: f32,
+        size: f32,
+        gaze_x: f32,
+        gaze_y: f32,
+    },
+    /// 羞明（解像度依存の bloom）。
     Photophobia,
+    /// 夜盲。
+    NightBlindness,
+
+    // --- 平衡感覚 / めまい ---
+    /// 浮動性めまい（時間依存）。
+    Vertigo,
+    /// BPPV 回転性めまい（時間依存）。
+    BppvRotation,
+    /// 前庭神経炎。
+    VestibularNeuritis,
+
+    // --- 複視 / 眼振 / 光芒 ---
+    /// 複視。`offset_x`/`offset_y`: 幽霊像のずれ（min(W,H) 比のピクセル）, `ghost_strength`: 幽霊像強度。
+    Diplopia {
+        offset_x: f32,
+        offset_y: f32,
+        ghost_strength: f32,
+    },
+    /// 眼振。`amplitude`: 振幅（min(W,H) 比）, `direction_deg`: 揺れ方向（度数法）。
+    Nystagmus { amplitude: f32, direction_deg: f32 },
+    /// 光芒。`num_rays`/`ray_length_ratio`/`threshold`/`dispersion`。
+    Starbursts {
+        num_rays: u32,
+        ray_length_ratio: f32,
+        threshold: f32,
+        dispersion: f32,
+    },
+
+    // --- 眼精疲労 ---
+    /// 眼精疲労。
+    EyeStrain,
+    /// ドライアイ。
+    DryEye,
+
+    // --- 変視症 / コントラスト / ピクセル化 ---
+    /// 変視症（歪み）。`freq`: 空間周波数, `seed`: 歪み場シード。
+    Metamorphopsia { freq: f32, seed: u64 },
+    /// コントラスト感度低下。
+    ContrastSensitivity,
+    /// ディテールロス（ピクセル化）。`cell_size`: タイルサイズ (px)。
+    DetailLoss { cell_size: u32 },
+
+    // --- 閃輝暗点 ---
+    /// 閃輝暗点。
+    Teichopsia,
+    /// 閃輝（光の星）。`seed`: ランダムシード。
+    FlickeringStars { seed: u64 },
+}
+
+impl VisionFilter {
+    /// CPU `apply` 経路用に `sensus_core::Filter` へ変換する。payload は
+    /// そのまま転送する。色覚・焦点などパラメータ無しバリアントは引数なしの
+    /// sensus バリアントへマップする。
+    fn to_sensus(self) -> sensus_core::Filter {
+        use sensus_core::Filter as F;
+        match self {
+            VisionFilter::Protanopia => F::Protanopia,
+            VisionFilter::Deuteranopia => F::Deuteranopia,
+            VisionFilter::Tritanopia => F::Tritanopia,
+            VisionFilter::Achromatopsia => F::Achromatopsia,
+            VisionFilter::Tetrachromacy => F::Tetrachromacy,
+            VisionFilter::Myopia => F::Myopia,
+            VisionFilter::Hyperopia => F::Hyperopia,
+            VisionFilter::Presbyopia => F::Presbyopia,
+            VisionFilter::Astigmatism { axis_deg } => F::Astigmatism { axis_deg },
+            VisionFilter::Glaucoma { mode } => F::Glaucoma {
+                mode: mode.to_sensus(),
+            },
+            VisionFilter::MacularDegeneration => F::MacularDegeneration,
+            VisionFilter::Hemianopia { side } => F::Hemianopia { side },
+            VisionFilter::TunnelVision => F::TunnelVision,
+            VisionFilter::Cataract { seed } => F::Cataract { seed },
+            VisionFilter::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            } => F::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            },
+            VisionFilter::Photophobia => F::Photophobia,
+            VisionFilter::NightBlindness => F::NightBlindness,
+            VisionFilter::Vertigo => F::Vertigo,
+            VisionFilter::BppvRotation => F::BppvRotation,
+            VisionFilter::VestibularNeuritis => F::VestibularNeuritis,
+            VisionFilter::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            } => F::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            },
+            VisionFilter::Nystagmus {
+                amplitude,
+                direction_deg,
+            } => F::Nystagmus {
+                amplitude,
+                direction_deg,
+            },
+            VisionFilter::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            } => F::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            },
+            VisionFilter::EyeStrain => F::EyeStrain,
+            VisionFilter::DryEye => F::DryEye,
+            VisionFilter::Metamorphopsia { freq, seed } => F::Metamorphopsia { freq, seed },
+            VisionFilter::ContrastSensitivity => F::ContrastSensitivity,
+            VisionFilter::DetailLoss { cell_size } => F::DetailLoss { cell_size },
+            VisionFilter::Teichopsia => F::Teichopsia,
+            VisionFilter::FlickeringStars { seed } => F::FlickeringStars { seed },
+        }
+    }
 }
 
 /// 指定フィルタの GLSL ES 3.00 ソースを返す。
@@ -44,6 +241,9 @@ pub enum VisionFilter {
 /// **用途**: ビルド時に Flutter アセット（または impeller 変換前の中間 `.frag`）
 /// へ書き出す同期スクリプト用。実機ランタイムでこの文字列を直接 Flutter の
 /// `FragmentProgram` に流し込むことはできない（理由は docs/sensus-integration.md）。
+///
+/// sensus_core の全 vision フィルタに `*_glsl()` getter が存在するため、本関数は
+/// 全 [`VisionFilter`] で非空ソースを返す（shader 非対応フィルタは無い）。
 #[flutter_rust_bridge::frb(sync)]
 pub fn vision_shader_glsl(filter: VisionFilter) -> String {
     match filter {
@@ -51,8 +251,32 @@ pub fn vision_shader_glsl(filter: VisionFilter) -> String {
         VisionFilter::Deuteranopia => shaders::deuteranopia_glsl(),
         VisionFilter::Tritanopia => shaders::tritanopia_glsl(),
         VisionFilter::Achromatopsia => shaders::achromatopsia_glsl(),
+        VisionFilter::Tetrachromacy => shaders::tetrachromacy_glsl(),
         VisionFilter::Myopia => shaders::myopia_glsl(),
+        VisionFilter::Hyperopia => shaders::hyperopia_glsl(),
+        VisionFilter::Presbyopia => shaders::presbyopia_glsl(),
+        VisionFilter::Astigmatism { .. } => shaders::astigmatism_glsl(),
+        VisionFilter::Glaucoma { .. } => shaders::glaucoma_glsl(),
+        VisionFilter::MacularDegeneration => shaders::macular_degeneration_glsl(),
+        VisionFilter::Hemianopia { .. } => shaders::hemianopia_glsl(),
+        VisionFilter::TunnelVision => shaders::tunnel_vision_glsl(),
+        VisionFilter::Cataract { .. } => shaders::cataract_glsl(),
+        VisionFilter::Floaters { .. } => shaders::floaters_glsl(),
         VisionFilter::Photophobia => shaders::photophobia_glsl(),
+        VisionFilter::NightBlindness => shaders::nyctalopia_glsl(),
+        VisionFilter::Vertigo => shaders::vertigo_glsl(),
+        VisionFilter::BppvRotation => shaders::bppv_rotation_glsl(),
+        VisionFilter::VestibularNeuritis => shaders::vestibular_neuritis_glsl(),
+        VisionFilter::Diplopia { .. } => shaders::diplopia_glsl(),
+        VisionFilter::Nystagmus { .. } => shaders::nystagmus_glsl(),
+        VisionFilter::Starbursts { .. } => shaders::starbursts_glsl(),
+        VisionFilter::EyeStrain => shaders::eye_strain_glsl(),
+        VisionFilter::DryEye => shaders::dry_eye_glsl(),
+        VisionFilter::Metamorphopsia { .. } => shaders::metamorphopsia_glsl(),
+        VisionFilter::ContrastSensitivity => shaders::contrast_sensitivity_glsl(),
+        VisionFilter::DetailLoss { .. } => shaders::detail_loss_glsl(),
+        VisionFilter::Teichopsia => shaders::teichopsia_glsl(),
+        VisionFilter::FlickeringStars { .. } => shaders::flickering_stars_glsl(),
     }
     .to_string()
 }
@@ -60,68 +284,224 @@ pub fn vision_shader_glsl(filter: VisionFilter) -> String {
 /// 指定フィルタの uniform を、FragmentProgram に `setFloat(i, ..)` する順序の
 /// flat な `Vec<f32>` にして返す。
 ///
-/// `sampler2D uTexture`（= 入力画像）は `setFloat` の対象外なので含めない。
-/// Flutter 側では float uniform を `setFloat(0..)` で順に積み、サンプラは
-/// `setImageSampler(0, ..)` で別途渡す。各インデックスの意味は
-/// [`vision_uniform_layout`] が返すラベルと一致する（同じ順序）。
+/// `sampler2D uTexture`（= 入力画像）および `uMask`（floaters のマスク）は
+/// `setFloat` の対象外なので含めない。Flutter 側では float uniform を `setFloat(0..)`
+/// で順に積み、サンプラは `setImageSampler(..)` で別途渡す。各インデックスの意味は
+/// [`vision_uniform_layout`] が返すラベルと一致する（同じ順序、同じ長さ）。
 ///
 /// # 引数
-/// - `strength`: 0.0..=1.0（範囲外は sensus 側で clamp される）。
-/// - `width` / `height`: 入力画像のピクセルサイズ。解像度依存フィルタ
-///   （Myopia / Photophobia）の半径・texel size 算出に使う。色覚 4 種では未使用。
-/// - `seed`: ランダム系フィルタ用シード。MVP のフィルタでは未使用だが、後続で
-///   Cataract / Floaters 等を足すときに使う（署名を安定させるため今から受ける）。
+/// - `strength`: 0.0..=1.0（範囲外・NaN は sensus 側 `normalize_strength` で clamp / NaN→0）。
+/// - `time`: 秒単位の時間。時間依存フィルタ（Vertigo / BppvRotation）の `uTime` に渡す。
+///   それ以外のフィルタでは無視される（sensus の uniforms getter が time を取らないため）。
+/// - `width` / `height`: 入力画像のピクセルサイズ。解像度依存フィルタの半径・texel size・
+///   resolution・aspect の算出に使う。
 ///
-/// # 各フィルタの返却レイアウト
-/// - Protanopia / Deuteranopia / Tritanopia:
-///   `[uStrength, uMatrix0, uMatrix1, .., uMatrix8]`（計 10 要素）
-/// - Achromatopsia: `[uStrength, uRWeight, uGWeight, uBWeight]`（計 4 要素）
-/// - Myopia: `[uStrength, uRadiusPx, uTexelSizeX, uTexelSizeY]`（計 4 要素）
-/// - Photophobia: `[uRadiusPx, uTexelSizeX, uTexelSizeY]`（計 3 要素。
-///   photophobia.frag は `uStrength` を持たない — strength は半径へ畳み込み済み）
+/// # u32 シード / count / int の扱い
+/// GLSL で `uint`/`int` の uniform（`uSeed`, `uCount`）も f32 に詰める。f32 は 2^24 を
+/// 超える整数を正確に表せないため、seed が巨大だと精度が落ちる（モジュール doc 参照）。
 #[flutter_rust_bridge::frb(sync)]
 pub fn vision_uniforms(
     filter: VisionFilter,
     strength: f32,
+    time: f32,
     width: u32,
     height: u32,
-    _seed: u64,
 ) -> Vec<f32> {
     // texel_size = 1/dim を計算する際、0 だと +inf が下流（setFloat → シェーダ）へ
     // 流れてしまう。呼び元は実画像サイズを渡す前提だが、防御的に最低 1 にする。
     let width = width.max(1);
     let height = height.max(1);
+    let min_dim = width.min(height);
+    let texel_x = 1.0 / width as f32;
+    let texel_y = 1.0 / height as f32;
     match filter {
-        VisionFilter::Protanopia => {
-            let u = shaders::protanopia_uniforms(strength);
-            color_matrix_flat(u)
-        }
-        VisionFilter::Deuteranopia => {
-            let u = shaders::deuteranopia_uniforms(strength);
-            color_matrix_flat(u)
-        }
-        VisionFilter::Tritanopia => {
-            let u = shaders::tritanopia_uniforms(strength);
-            color_matrix_flat(u)
-        }
+        VisionFilter::Protanopia => color_matrix_flat(shaders::protanopia_uniforms(strength)),
+        VisionFilter::Deuteranopia => color_matrix_flat(shaders::deuteranopia_uniforms(strength)),
+        VisionFilter::Tritanopia => color_matrix_flat(shaders::tritanopia_uniforms(strength)),
         VisionFilter::Achromatopsia => {
             let u = shaders::achromatopsia_uniforms(strength);
             vec![u.strength, u.r_weight, u.g_weight, u.b_weight]
         }
+        VisionFilter::Tetrachromacy => {
+            vec![shaders::tetrachromacy_uniforms(strength).strength]
+        }
         VisionFilter::Myopia => {
-            let u = shaders::myopia_uniforms(strength, width.min(height));
-            vec![
-                u.strength,
-                u.radius_px,
-                1.0 / width as f32,
-                1.0 / height as f32,
-            ]
+            let u = shaders::myopia_uniforms(strength, min_dim);
+            vec![u.strength, u.radius_px, texel_x, texel_y]
+        }
+        VisionFilter::Hyperopia => {
+            let u = shaders::hyperopia_uniforms(strength, min_dim);
+            vec![u.strength, u.radius_px, texel_x, texel_y]
+        }
+        VisionFilter::Presbyopia => {
+            let u = shaders::presbyopia_uniforms(strength, min_dim);
+            vec![u.strength, u.radius_px, texel_x, texel_y]
+        }
+        VisionFilter::Astigmatism { axis_deg } => {
+            let u = shaders::astigmatism_uniforms(strength, min_dim, axis_deg);
+            vec![u.strength, u.radius_px, u.axis_deg, texel_x, texel_y]
+        }
+        VisionFilter::Glaucoma { mode } => {
+            let u = shaders::glaucoma_uniforms(strength, width, height, mode.to_sensus());
+            vec![u.strength, u.aspect, u.mode as f32]
+        }
+        VisionFilter::MacularDegeneration => {
+            let u = shaders::macular_degeneration_uniforms(strength, width, height);
+            vec![u.strength, u.aspect]
+        }
+        VisionFilter::Hemianopia { side } => {
+            // 公開 API 規約: 0.0=左欠損, 1.0=右欠損。frag の uSide は 1.0=右, -1.0=左。
+            // shaders::hemianopia_uniforms は GLSL 内部値をそのまま渡すため、ここで変換する。
+            let glsl_side = if side >= 0.5 { 1.0 } else { -1.0 };
+            let u = shaders::hemianopia_uniforms(strength, glsl_side);
+            vec![u.strength, u.side]
+        }
+        VisionFilter::TunnelVision => {
+            let u = shaders::tunnel_vision_uniforms(strength, width, height);
+            vec![u.strength, u.aspect]
+        }
+        VisionFilter::Cataract { seed } => {
+            let u = shaders::cataract_uniforms(strength, seed);
+            // frag: uStrength, uint uSeed, vec2 uResolution
+            vec![u.strength, u.seed as f32, width as f32, height as f32]
+        }
+        VisionFilter::Floaters { .. } => {
+            // frag: uStrength のみ（マスクは uMask テクスチャで別途渡す）。
+            vec![shaders::floaters_uniforms(strength).strength]
         }
         VisionFilter::Photophobia => {
             let u = shaders::photophobia_uniforms(strength, width, height);
             // photophobia.frag は uStrength を持たない。strength は radius_px に
             // 畳み込まれているため、uniform は radius + texel のみ。
             vec![u.radius_px, u.texel_size[0], u.texel_size[1]]
+        }
+        VisionFilter::NightBlindness => {
+            vec![shaders::nyctalopia_uniforms(strength).strength]
+        }
+        VisionFilter::Vertigo => {
+            let u = shaders::vertigo_uniforms(strength, time, width, height);
+            vec![
+                u.strength,
+                u.time,
+                u.aspect,
+                u.radius_px,
+                u.texel_size[0],
+                u.texel_size[1],
+            ]
+        }
+        VisionFilter::BppvRotation => {
+            let u = shaders::bppv_rotation_uniforms(strength, time, width, height);
+            vec![u.strength, u.time, u.aspect]
+        }
+        VisionFilter::VestibularNeuritis => {
+            let u = shaders::vestibular_neuritis_uniforms(strength, width, height);
+            vec![
+                u.strength,
+                u.radius_px,
+                u.shift_texel,
+                u.texel_size[0],
+                u.texel_size[1],
+            ]
+        }
+        VisionFilter::Diplopia {
+            offset_x,
+            offset_y,
+            ghost_strength,
+        } => {
+            // offset は min(W,H) 比。CPU vision::diplopia と同じくピクセルへ展開してから
+            // テクセル化する（diplopia_uniforms が px → texel 変換を担う）。
+            let offset_x_px = offset_x * min_dim as f32;
+            let offset_y_px = offset_y * min_dim as f32;
+            let u = shaders::diplopia_uniforms(
+                strength,
+                offset_x_px,
+                offset_y_px,
+                ghost_strength,
+                width,
+                height,
+            );
+            vec![
+                u.strength,
+                u.offset_x_texel,
+                u.offset_y_texel,
+                u.ghost_strength,
+            ]
+        }
+        VisionFilter::Nystagmus {
+            amplitude,
+            direction_deg,
+        } => {
+            let u = shaders::nystagmus_uniforms(strength, amplitude, direction_deg, min_dim);
+            vec![u.strength, u.radius_px, u.direction_deg, texel_x, texel_y]
+        }
+        VisionFilter::Starbursts {
+            num_rays,
+            ray_length_ratio,
+            threshold,
+            dispersion,
+        } => {
+            let u = shaders::starbursts_uniforms(
+                strength,
+                threshold,
+                dispersion,
+                num_rays,
+                ray_length_ratio,
+                width,
+                height,
+            );
+            // frag 順: uStrength, uThreshold, uDispersion, uNumRays, uRayLengthPx, uTexelSize
+            vec![
+                u.strength,
+                u.threshold,
+                u.dispersion,
+                u.num_rays,
+                u.ray_length_px,
+                u.texel_size[0],
+                u.texel_size[1],
+            ]
+        }
+        VisionFilter::EyeStrain => {
+            let u = shaders::eye_strain_uniforms(strength, width, height);
+            vec![u.strength, u.radius_px, u.texel_size[0], u.texel_size[1]]
+        }
+        VisionFilter::DryEye => {
+            let u = shaders::dry_eye_uniforms(strength, width, height);
+            vec![u.strength, u.texel_size[0], u.texel_size[1]]
+        }
+        VisionFilter::Metamorphopsia { freq, seed } => {
+            let u = shaders::metamorphopsia_uniforms(strength, freq, seed, width, height);
+            vec![
+                u.strength,
+                u.freq,
+                u.seed as f32,
+                u.texel_size[0],
+                u.texel_size[1],
+            ]
+        }
+        VisionFilter::ContrastSensitivity => {
+            vec![shaders::contrast_sensitivity_uniforms(strength).strength]
+        }
+        VisionFilter::DetailLoss { .. } => {
+            // detail_loss.frag: uStrength, vec2 uResolution。
+            // cell_size は CPU 実装（detail_loss_with_cell_size）専用で、GLSL は
+            // strength からタイルサイズを内部算出するため uniform には乗らない。
+            let u = shaders::detail_loss_uniforms(strength);
+            vec![u.strength, width as f32, height as f32]
+        }
+        VisionFilter::Teichopsia => {
+            let u = shaders::teichopsia_uniforms(strength, width, height);
+            vec![u.strength, u.aspect]
+        }
+        VisionFilter::FlickeringStars { seed } => {
+            let u = shaders::flickering_stars_uniforms(strength, seed);
+            // frag 順: uStrength, uint uSeed, int uCount, vec2 uResolution
+            vec![
+                u.strength,
+                u.seed as f32,
+                u.count as f32,
+                width as f32,
+                height as f32,
+            ]
         }
     }
 }
@@ -155,17 +535,86 @@ pub fn vision_uniform_layout(filter: VisionFilter) -> Vec<String> {
             "uMatrix[8]",
         ],
         VisionFilter::Achromatopsia => &["uStrength", "uRWeight", "uGWeight", "uBWeight"],
-        VisionFilter::Myopia => &["uStrength", "uRadiusPx", "uTexelSize.x", "uTexelSize.y"],
+        VisionFilter::Tetrachromacy
+        | VisionFilter::NightBlindness
+        | VisionFilter::ContrastSensitivity => &["uStrength"],
+        VisionFilter::Floaters { .. } => &["uStrength"],
+        VisionFilter::Myopia | VisionFilter::Hyperopia | VisionFilter::Presbyopia => {
+            &["uStrength", "uRadiusPx", "uTexelSize.x", "uTexelSize.y"]
+        }
+        VisionFilter::Astigmatism { .. } => &[
+            "uStrength",
+            "uRadiusPx",
+            "uAxisDeg",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::Glaucoma { .. } => &["uStrength", "uAspect", "uMode"],
+        VisionFilter::MacularDegeneration
+        | VisionFilter::TunnelVision
+        | VisionFilter::Teichopsia => &["uStrength", "uAspect"],
+        VisionFilter::Hemianopia { .. } => &["uStrength", "uSide"],
+        VisionFilter::Cataract { .. } => &["uStrength", "uSeed", "uResolution.x", "uResolution.y"],
         VisionFilter::Photophobia => &["uRadiusPx", "uTexelSize.x", "uTexelSize.y"],
+        VisionFilter::Vertigo => &[
+            "uStrength",
+            "uTime",
+            "uAspect",
+            "uRadiusPx",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::BppvRotation => &["uStrength", "uTime", "uAspect"],
+        VisionFilter::VestibularNeuritis => &[
+            "uStrength",
+            "uRadiusPx",
+            "uShiftTexel",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::Diplopia { .. } => &["uStrength", "uOffsetX", "uOffsetY", "uGhostStrength"],
+        VisionFilter::Nystagmus { .. } => &[
+            "uStrength",
+            "uRadiusPx",
+            "uDirectionDeg",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::Starbursts { .. } => &[
+            "uStrength",
+            "uThreshold",
+            "uDispersion",
+            "uNumRays",
+            "uRayLengthPx",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::EyeStrain => &["uStrength", "uRadiusPx", "uTexelSize.x", "uTexelSize.y"],
+        VisionFilter::DryEye => &["uStrength", "uTexelSize.x", "uTexelSize.y"],
+        VisionFilter::Metamorphopsia { .. } => &[
+            "uStrength",
+            "uFreq",
+            "uSeed",
+            "uTexelSize.x",
+            "uTexelSize.y",
+        ],
+        VisionFilter::DetailLoss { .. } => &["uStrength", "uResolution.x", "uResolution.y"],
+        VisionFilter::FlickeringStars { .. } => &[
+            "uStrength",
+            "uSeed",
+            "uCount",
+            "uResolution.x",
+            "uResolution.y",
+        ],
     };
     labels.iter().map(|s| s.to_string()).collect()
 }
 
-/// （将来用）sensus-core の CPU `apply` を 1 つだけ薄く公開する。
+/// sensus-core の CPU `apply` を薄く公開する。全 [`VisionFilter`] に対応する
+/// （sensus の `apply` は網羅 match なので payload 付きフィルタも CPU で適用可能）。
 ///
-/// GPU（FragmentProgram）経路が主のため MVP では未使用だが、テストや
-/// GPU 非対応環境のフォールバックに備えて残す。生 RGBA8（`width * height * 4`
-/// バイト）を入力し、同じレイアウトの RGBA8 を返す。
+/// GPU（FragmentProgram）経路が主だが、テストや GPU 非対応環境のフォールバックに使う。
+/// 生 RGBA8（`width * height * 4` バイト）を入力し、同じレイアウトの RGBA8 を返す。
 ///
 /// 注意: これは sensus の `image::DynamicImage` 経路を通すため GPU 経路より遅い。
 /// 大きな画像をリアルタイム処理する用途には使わないこと。
@@ -177,8 +626,6 @@ pub fn apply_vision_cpu_rgba8(
     height: u32,
     strength: f32,
 ) -> Result<Vec<u8>, String> {
-    use sensus_core::Filter;
-
     let expected = (width as usize) * (height as usize) * 4;
     if rgba8.len() != expected {
         return Err(format!(
@@ -192,16 +639,8 @@ pub fn apply_vision_cpu_rgba8(
         .ok_or_else(|| "failed to build RgbaImage from raw buffer".to_string())?;
     let dynimg = image::DynamicImage::ImageRgba8(img);
 
-    let f = match filter {
-        VisionFilter::Protanopia => Filter::Protanopia,
-        VisionFilter::Deuteranopia => Filter::Deuteranopia,
-        VisionFilter::Tritanopia => Filter::Tritanopia,
-        VisionFilter::Achromatopsia => Filter::Achromatopsia,
-        VisionFilter::Myopia => Filter::Myopia,
-        VisionFilter::Photophobia => Filter::Photophobia,
-    };
-
-    let out = sensus_core::apply(f, dynimg, strength).map_err(|e| e.to_string())?;
+    let out =
+        sensus_core::apply(filter.to_sensus(), dynimg, strength).map_err(|e| e.to_string())?;
     Ok(out.to_rgba8().into_raw())
 }
 
@@ -209,96 +648,74 @@ pub fn apply_vision_cpu_rgba8(
 mod tests {
     use super::*;
 
-    #[test]
-    fn glsl_sources_are_non_empty() {
-        for f in [
-            VisionFilter::Protanopia,
-            VisionFilter::Deuteranopia,
-            VisionFilter::Tritanopia,
-            VisionFilter::Achromatopsia,
-            VisionFilter::Myopia,
-            VisionFilter::Photophobia,
-        ] {
-            assert!(!vision_shader_glsl(f).is_empty());
-        }
-    }
-
-    #[test]
-    fn color_matrix_layout_matches_uniforms_len() {
-        for f in [
-            VisionFilter::Protanopia,
-            VisionFilter::Deuteranopia,
-            VisionFilter::Tritanopia,
-        ] {
-            let u = vision_uniforms(f, 1.0, 100, 100, 0);
-            let l = vision_uniform_layout(f);
-            assert_eq!(u.len(), 10);
-            assert_eq!(u.len(), l.len());
-        }
-    }
-
-    #[test]
-    fn achromatopsia_layout_matches() {
-        let u = vision_uniforms(VisionFilter::Achromatopsia, 1.0, 100, 100, 0);
-        let l = vision_uniform_layout(VisionFilter::Achromatopsia);
-        assert_eq!(u.len(), 4);
-        assert_eq!(u.len(), l.len());
-        // BT.709 luma weights が sensus からそのまま来ること
-        assert!((u[1] - 0.2126).abs() < 1e-6);
-    }
-
-    #[test]
-    fn myopia_uniforms_include_texel_size() {
-        let u = vision_uniforms(VisionFilter::Myopia, 1.0, 200, 100, 0);
-        let l = vision_uniform_layout(VisionFilter::Myopia);
-        assert_eq!(u.len(), 4);
-        assert_eq!(u.len(), l.len());
-        // texel size = 1/width, 1/height
-        assert!((u[2] - 1.0 / 200.0).abs() < 1e-6);
-        assert!((u[3] - 1.0 / 100.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn photophobia_has_no_strength_uniform() {
-        let u = vision_uniforms(VisionFilter::Photophobia, 1.0, 200, 100, 0);
-        let l = vision_uniform_layout(VisionFilter::Photophobia);
-        assert_eq!(u.len(), 3);
-        assert_eq!(u.len(), l.len());
-        assert_eq!(l[0], "uRadiusPx");
-    }
-
-    #[test]
-    fn cpu_apply_rejects_wrong_buffer_len() {
-        let r = apply_vision_cpu_rgba8(VisionFilter::Protanopia, vec![0u8; 10], 4, 4, 1.0);
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn cpu_apply_roundtrips_size() {
-        let w = 4u32;
-        let h = 4u32;
-        let buf = vec![128u8; (w * h * 4) as usize];
-        let out = apply_vision_cpu_rgba8(VisionFilter::Protanopia, buf, w, h, 1.0).unwrap();
-        assert_eq!(out.len(), (w * h * 4) as usize);
-    }
-
-    /// 全フィルタを 1 ループで列挙するためのヘルパ。バリアントが増えたら
-    /// ここに追加するだけで全網羅テストが拾う。
-    const ALL_FILTERS: [VisionFilter; 6] = [
+    /// 全 vision バリアントを 1 ループで列挙するためのヘルパ。バリアントが増えたら
+    /// ここに追加するだけで全網羅テストが拾う。payload 付きは代表値を入れる。
+    const ALL_FILTERS: [VisionFilter; 30] = [
         VisionFilter::Protanopia,
         VisionFilter::Deuteranopia,
         VisionFilter::Tritanopia,
         VisionFilter::Achromatopsia,
+        VisionFilter::Tetrachromacy,
         VisionFilter::Myopia,
+        VisionFilter::Hyperopia,
+        VisionFilter::Presbyopia,
+        VisionFilter::Astigmatism { axis_deg: 45.0 },
+        VisionFilter::Glaucoma {
+            mode: VisionGlaucomaMode::Biarcuate,
+        },
+        VisionFilter::MacularDegeneration,
+        VisionFilter::Hemianopia { side: 1.0 },
+        VisionFilter::TunnelVision,
+        VisionFilter::Cataract { seed: 7 },
+        VisionFilter::Floaters {
+            seed: 7,
+            density: 1.0,
+            size: 2.0,
+            gaze_x: 0.5,
+            gaze_y: 0.5,
+        },
         VisionFilter::Photophobia,
+        VisionFilter::NightBlindness,
+        VisionFilter::Vertigo,
+        VisionFilter::BppvRotation,
+        VisionFilter::VestibularNeuritis,
+        VisionFilter::Diplopia {
+            offset_x: 0.01,
+            offset_y: 0.0,
+            ghost_strength: 0.5,
+        },
+        VisionFilter::Nystagmus {
+            amplitude: 0.02,
+            direction_deg: 0.0,
+        },
+        VisionFilter::Starbursts {
+            num_rays: 6,
+            ray_length_ratio: 0.1,
+            threshold: 0.8,
+            dispersion: 0.3,
+        },
+        VisionFilter::EyeStrain,
+        VisionFilter::DryEye,
+        VisionFilter::Metamorphopsia { freq: 8.0, seed: 3 },
+        VisionFilter::ContrastSensitivity,
+        VisionFilter::DetailLoss { cell_size: 8 },
+        VisionFilter::Teichopsia,
+        VisionFilter::FlickeringStars { seed: 5 },
     ];
+
+    #[test]
+    fn glsl_sources_are_non_empty_all_filters() {
+        for f in ALL_FILTERS {
+            assert!(!vision_shader_glsl(f).is_empty(), "{f:?}: empty GLSL");
+        }
+    }
 
     /// 最重要不変条件: 全バリアントで uniforms の長さが layout の長さと一致する。
     /// ズレると Dart 側 setFloat(i, ..) のインデックスが壊れる。
     #[test]
     fn all_filters_uniforms_len_matches_layout() {
         for f in ALL_FILTERS {
-            let u = vision_uniforms(f, 0.5, 256, 128, 0);
+            let u = vision_uniforms(f, 0.5, 0.3, 256, 128);
             let l = vision_uniform_layout(f);
             assert_eq!(
                 u.len(),
@@ -321,62 +738,6 @@ mod tests {
         }
     }
 
-    /// 解像度依存フィルタ（Myopia）: width/height を変えると texel size と
-    /// 半径が変わる。解像度に依存しない色覚フィルタは値が変わらないことも確認。
-    #[test]
-    fn myopia_uniforms_track_resolution() {
-        let small = vision_uniforms(VisionFilter::Myopia, 1.0, 100, 100, 0);
-        let large = vision_uniforms(VisionFilter::Myopia, 1.0, 400, 400, 0);
-        // texel size = 1/dim なので解像度で変わる。
-        assert!((small[2] - 1.0 / 100.0).abs() < 1e-6);
-        assert!((large[2] - 1.0 / 400.0).abs() < 1e-6);
-        assert_ne!(small[2], large[2]);
-        // radius_px は min(width,height) に比例するので大きい画像ほど大きい。
-        assert!(large[1] > small[1]);
-    }
-
-    /// 解像度依存フィルタ（Photophobia）: 解像度で radius と texel が変わる。
-    #[test]
-    fn photophobia_uniforms_track_resolution() {
-        let small = vision_uniforms(VisionFilter::Photophobia, 1.0, 100, 100, 0);
-        let large = vision_uniforms(VisionFilter::Photophobia, 1.0, 400, 400, 0);
-        // layout: [uRadiusPx, uTexelSize.x, uTexelSize.y]
-        assert!((small[1] - 1.0 / 100.0).abs() < 1e-6);
-        assert!((large[1] - 1.0 / 400.0).abs() < 1e-6);
-        assert!(large[0] > small[0]); // radius_px が解像度で増える
-    }
-
-    /// 色覚フィルタは解像度に依存しない（width/height を変えても uniform 不変）。
-    #[test]
-    fn color_matrix_uniforms_ignore_resolution() {
-        for f in [
-            VisionFilter::Protanopia,
-            VisionFilter::Deuteranopia,
-            VisionFilter::Tritanopia,
-            VisionFilter::Achromatopsia,
-        ] {
-            let a = vision_uniforms(f, 0.7, 100, 100, 0);
-            let b = vision_uniforms(f, 0.7, 999, 333, 0);
-            assert_eq!(
-                a, b,
-                "{f:?}: color filter uniforms must not depend on resolution"
-            );
-        }
-    }
-
-    /// Photophobia は uStrength uniform を持たないが、strength は radius_px に
-    /// 畳み込まれている。strength を上げると radius_px が増えることの回帰。
-    #[test]
-    fn photophobia_strength_folds_into_radius() {
-        let weak = vision_uniforms(VisionFilter::Photophobia, 0.1, 200, 200, 0);
-        let strong = vision_uniforms(VisionFilter::Photophobia, 0.9, 200, 200, 0);
-        // index 0 = uRadiusPx
-        assert!(strong[0] > weak[0]);
-        // strength=0 なら bloom 半径は 0。
-        let zero = vision_uniforms(VisionFilter::Photophobia, 0.0, 200, 200, 0);
-        assert!(zero[0].abs() < 1e-6);
-    }
-
     /// strength の境界・異常値を渡しても panic せず、長さ不変・有限値が返る
     /// （clamp / NaN→0 は sensus 側 normalize_strength に委譲）。
     #[test]
@@ -384,7 +745,7 @@ mod tests {
         for f in ALL_FILTERS {
             let layout_len = vision_uniform_layout(f).len();
             for s in [0.0_f32, 1.0, -5.0, 100.0, f32::NAN, f32::INFINITY] {
-                let u = vision_uniforms(f, s, 256, 128, 0);
+                let u = vision_uniforms(f, s, 0.0, 256, 128);
                 assert_eq!(u.len(), layout_len, "{f:?} s={s}: length changed");
                 for (i, v) in u.iter().enumerate() {
                     assert!(v.is_finite(), "{f:?} s={s}: uniform[{i}] not finite ({v})");
@@ -399,7 +760,7 @@ mod tests {
     fn zero_dimensions_produce_finite_uniforms() {
         for f in ALL_FILTERS {
             for (w, h) in [(0u32, 0u32), (0, 128), (256, 0)] {
-                let u = vision_uniforms(f, 1.0, w, h, 0);
+                let u = vision_uniforms(f, 1.0, 0.5, w, h);
                 for (i, v) in u.iter().enumerate() {
                     assert!(
                         v.is_finite(),
@@ -421,5 +782,173 @@ mod tests {
             let out = apply_vision_cpu_rgba8(f, buf, w, h, 0.6).unwrap();
             assert_eq!(out.len(), len, "{f:?}: output size mismatch");
         }
+    }
+
+    #[test]
+    fn cpu_apply_rejects_wrong_buffer_len() {
+        let r = apply_vision_cpu_rgba8(VisionFilter::Protanopia, vec![0u8; 10], 4, 4, 1.0);
+        assert!(r.is_err());
+    }
+
+    // --- フィルタ別レイアウト・値の回帰 ---
+
+    #[test]
+    fn color_matrix_layout_matches_uniforms_len() {
+        for f in [
+            VisionFilter::Protanopia,
+            VisionFilter::Deuteranopia,
+            VisionFilter::Tritanopia,
+        ] {
+            let u = vision_uniforms(f, 1.0, 0.0, 100, 100);
+            assert_eq!(u.len(), 10);
+        }
+    }
+
+    #[test]
+    fn achromatopsia_bt709_weights() {
+        let u = vision_uniforms(VisionFilter::Achromatopsia, 1.0, 0.0, 100, 100);
+        assert_eq!(u.len(), 4);
+        assert!((u[1] - 0.2126).abs() < 1e-6);
+    }
+
+    #[test]
+    fn myopia_uniforms_include_texel_size() {
+        let u = vision_uniforms(VisionFilter::Myopia, 1.0, 0.0, 200, 100);
+        assert_eq!(u.len(), 4);
+        assert!((u[2] - 1.0 / 200.0).abs() < 1e-6);
+        assert!((u[3] - 1.0 / 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn photophobia_has_no_strength_uniform() {
+        let u = vision_uniforms(VisionFilter::Photophobia, 1.0, 0.0, 200, 100);
+        let l = vision_uniform_layout(VisionFilter::Photophobia);
+        assert_eq!(u.len(), 3);
+        assert_eq!(l[0], "uRadiusPx");
+    }
+
+    /// 色覚フィルタは解像度に依存しない（width/height を変えても uniform 不変）。
+    #[test]
+    fn color_matrix_uniforms_ignore_resolution() {
+        for f in [
+            VisionFilter::Protanopia,
+            VisionFilter::Deuteranopia,
+            VisionFilter::Tritanopia,
+            VisionFilter::Achromatopsia,
+        ] {
+            let a = vision_uniforms(f, 0.7, 0.0, 100, 100);
+            let b = vision_uniforms(f, 0.7, 0.0, 999, 333);
+            assert_eq!(
+                a, b,
+                "{f:?}: color filter uniforms must not depend on resolution"
+            );
+        }
+    }
+
+    /// 時間依存フィルタは uTime を反映する（time を変えると uniform が変わる）。
+    #[test]
+    fn time_dependent_filters_track_time() {
+        for f in [VisionFilter::Vertigo, VisionFilter::BppvRotation] {
+            let l = vision_uniform_layout(f);
+            assert!(
+                l.iter().any(|s| s == "uTime"),
+                "{f:?}: layout must contain uTime"
+            );
+            let a = vision_uniforms(f, 1.0, 0.0, 256, 128);
+            let b = vision_uniforms(f, 1.0, 1.5, 256, 128);
+            assert_ne!(a, b, "{f:?}: changing time must change uniforms");
+            // uTime はそのまま透過する
+            let idx = l.iter().position(|s| s == "uTime").unwrap();
+            assert!((b[idx] - 1.5).abs() < 1e-6);
+        }
+    }
+
+    /// 時間非依存フィルタは time を無視する（time を変えても uniform 不変）。
+    #[test]
+    fn time_independent_filters_ignore_time() {
+        for f in [
+            VisionFilter::Protanopia,
+            VisionFilter::Myopia,
+            VisionFilter::Nystagmus {
+                amplitude: 0.02,
+                direction_deg: 0.0,
+            },
+            VisionFilter::Glaucoma {
+                mode: VisionGlaucomaMode::Vignette,
+            },
+        ] {
+            let a = vision_uniforms(f, 0.7, 0.0, 256, 128);
+            let b = vision_uniforms(f, 0.7, 9.9, 256, 128);
+            assert_eq!(a, b, "{f:?}: must ignore time");
+        }
+    }
+
+    /// Glaucoma の uMode が VisionGlaucomaMode と 1 対 1 対応する。
+    #[test]
+    fn glaucoma_mode_maps_to_glsl_mode() {
+        let cases = [
+            (VisionGlaucomaMode::Vignette, 0.0),
+            (VisionGlaucomaMode::ArcuateSuperior, 1.0),
+            (VisionGlaucomaMode::ArcuateInferior, 2.0),
+            (VisionGlaucomaMode::Biarcuate, 3.0),
+        ];
+        for (mode, expected) in cases {
+            let u = vision_uniforms(VisionFilter::Glaucoma { mode }, 1.0, 0.0, 64, 64);
+            // layout: [uStrength, uAspect, uMode]
+            assert_eq!(u[2], expected, "{mode:?}");
+        }
+    }
+
+    /// Hemianopia: 公開 side(0=左,1=右) → frag uSide(-1=左,1=右) の変換。
+    #[test]
+    fn hemianopia_side_conversion() {
+        let right = vision_uniforms(VisionFilter::Hemianopia { side: 1.0 }, 1.0, 0.0, 64, 64);
+        let left = vision_uniforms(VisionFilter::Hemianopia { side: 0.0 }, 1.0, 0.0, 64, 64);
+        // layout: [uStrength, uSide]
+        assert_eq!(right[1], 1.0, "side=1.0(右) → uSide=1.0");
+        assert_eq!(left[1], -1.0, "side=0.0(左) → uSide=-1.0");
+    }
+
+    /// Cataract: seed が flat 配列に乗り、resolution が width/height で来る。
+    #[test]
+    fn cataract_seed_and_resolution() {
+        let u = vision_uniforms(VisionFilter::Cataract { seed: 42 }, 1.0, 0.0, 200, 100);
+        // layout: [uStrength, uSeed, uResolution.x, uResolution.y]
+        assert_eq!(u.len(), 4);
+        assert_eq!(u[1], 42.0);
+        assert_eq!(u[2], 200.0);
+        assert_eq!(u[3], 100.0);
+    }
+
+    /// FlickeringStars: seed と count(=strength*200) が乗る。
+    #[test]
+    fn flickering_stars_count_from_strength() {
+        let u = vision_uniforms(
+            VisionFilter::FlickeringStars { seed: 1 },
+            0.5,
+            0.0,
+            100,
+            100,
+        );
+        // layout: [uStrength, uSeed, uCount, uResolution.x, uResolution.y]
+        assert_eq!(u.len(), 5);
+        assert_eq!(u[1], 1.0); // seed
+        assert_eq!(u[2], 100.0); // count = 0.5 * 200
+    }
+
+    /// Starbursts: num_rays / ray_length_px / texel が乗る（7 要素）。
+    #[test]
+    fn starbursts_layout_seven() {
+        let f = VisionFilter::Starbursts {
+            num_rays: 8,
+            ray_length_ratio: 0.1,
+            threshold: 0.8,
+            dispersion: 0.3,
+        };
+        let u = vision_uniforms(f, 1.0, 0.0, 200, 100);
+        assert_eq!(u.len(), 7);
+        assert_eq!(u[3], 8.0); // uNumRays
+                               // ray_length_px = (0.1 * min(200,100)) as u32 = 10
+        assert_eq!(u[4], 10.0);
     }
 }

--- a/rust/src/api/sensus_bridge.rs
+++ b/rust/src/api/sensus_bridge.rs
@@ -314,7 +314,7 @@ pub fn vision_uniforms(
     let min_dim = width.min(height);
     let texel_x = 1.0 / width as f32;
     let texel_y = 1.0 / height as f32;
-    match filter {
+    let mut uniforms = match filter {
         VisionFilter::Protanopia => color_matrix_flat(shaders::protanopia_uniforms(strength)),
         VisionFilter::Deuteranopia => color_matrix_flat(shaders::deuteranopia_uniforms(strength)),
         VisionFilter::Tritanopia => color_matrix_flat(shaders::tritanopia_uniforms(strength)),
@@ -503,7 +503,17 @@ pub fn vision_uniforms(
                 height as f32,
             ]
         }
+    };
+    // 防御境界: payload 数値（axis_deg / freq / offset 等）に NaN/Inf が紛れ込んでも、
+    // Dart→FragmentProgram の setFloat に非有限値を渡さない。strength は sensus 側で
+    // normalize 済みだが、payload 由来の値はここが Dart への最後の関門。非有限は 0.0 に潰す
+    // （半径・係数いずれも 0 は「効果なし」側で安全）。呼び元は有限値を渡す前提。
+    for v in uniforms.iter_mut() {
+        if !v.is_finite() {
+            *v = 0.0;
+        }
     }
+    uniforms
 }
 
 /// `ColorMatrixUniforms` を `[uStrength, uMatrix0..8]` の flat 配列へ展開する。
@@ -650,6 +660,9 @@ mod tests {
 
     /// 全 vision バリアントを 1 ループで列挙するためのヘルパ。バリアントが増えたら
     /// ここに追加するだけで全網羅テストが拾う。payload 付きは代表値を入れる。
+    // 新しい VisionFilter variant を追加したらこの配列にも足すこと（網羅テスト用）。
+    // 本体の `vision_uniforms`/`vision_shader_glsl`/`to_sensus` は網羅 match なので、
+    // variant 追加自体はコンパイルエラーで気付ける。
     const ALL_FILTERS: [VisionFilter; 30] = [
         VisionFilter::Protanopia,
         VisionFilter::Deuteranopia,
@@ -767,6 +780,47 @@ mod tests {
                         "{f:?} {w}x{h}: uniform[{i}] not finite ({v})"
                     );
                 }
+            }
+        }
+    }
+
+    /// payload 数値に NaN/Inf が紛れても、出力 uniform は全て有限（境界ガードの回帰）。
+    #[test]
+    fn non_finite_payloads_are_sanitized() {
+        let nan = f32::NAN;
+        let inf = f32::INFINITY;
+        let cases = [
+            VisionFilter::Astigmatism { axis_deg: nan },
+            VisionFilter::Hemianopia { side: inf },
+            VisionFilter::Diplopia {
+                offset_x: nan,
+                offset_y: inf,
+                ghost_strength: nan,
+            },
+            VisionFilter::Nystagmus {
+                amplitude: inf,
+                direction_deg: nan,
+            },
+            VisionFilter::Starbursts {
+                num_rays: 6,
+                ray_length_ratio: nan,
+                threshold: inf,
+                dispersion: nan,
+            },
+            VisionFilter::Metamorphopsia { freq: inf, seed: 0 },
+            VisionFilter::Floaters {
+                seed: 0,
+                density: nan,
+                size: inf,
+                gaze_x: nan,
+                gaze_y: inf,
+            },
+        ];
+        for f in cases {
+            // time にも異常値を入れて二重に確認
+            let u = vision_uniforms(f, nan, inf, 128, 64);
+            for (i, v) in u.iter().enumerate() {
+                assert!(v.is_finite(), "{f:?}: uniform[{i}] not finite ({v})");
             }
         }
     }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -119,9 +119,9 @@ fn wire__crate__api__sensus_bridge__vision_uniform_layout_impl(
 fn wire__crate__api__sensus_bridge__vision_uniforms_impl(
     filter: impl CstDecode<crate::api::sensus_bridge::VisionFilter>,
     strength: impl CstDecode<f32>,
+    time: impl CstDecode<f32>,
     width: impl CstDecode<u32>,
     height: impl CstDecode<u32>,
-    _seed: impl CstDecode<u64>,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -132,16 +132,16 @@ fn wire__crate__api__sensus_bridge__vision_uniforms_impl(
         move || {
             let api_filter = filter.cst_decode();
             let api_strength = strength.cst_decode();
+            let api_time = time.cst_decode();
             let api_width = width.cst_decode();
             let api_height = height.cst_decode();
-            let api__seed = _seed.cst_decode();
             transform_result_dco::<_, _, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(crate::api::sensus_bridge::vision_uniforms(
                     api_filter,
                     api_strength,
+                    api_time,
                     api_width,
                     api_height,
-                    api__seed,
                 ))?;
                 Ok(output_ok)
             })())
@@ -181,17 +181,15 @@ impl CstDecode<u8> for u8 {
         self
     }
 }
-impl CstDecode<crate::api::sensus_bridge::VisionFilter> for i32 {
+impl CstDecode<crate::api::sensus_bridge::VisionGlaucomaMode> for i32 {
     // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
+    fn cst_decode(self) -> crate::api::sensus_bridge::VisionGlaucomaMode {
         match self {
-            0 => crate::api::sensus_bridge::VisionFilter::Protanopia,
-            1 => crate::api::sensus_bridge::VisionFilter::Deuteranopia,
-            2 => crate::api::sensus_bridge::VisionFilter::Tritanopia,
-            3 => crate::api::sensus_bridge::VisionFilter::Achromatopsia,
-            4 => crate::api::sensus_bridge::VisionFilter::Myopia,
-            5 => crate::api::sensus_bridge::VisionFilter::Photophobia,
-            _ => unreachable!("Invalid variant for VisionFilter: {}", self),
+            0 => crate::api::sensus_bridge::VisionGlaucomaMode::Vignette,
+            1 => crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateSuperior,
+            2 => crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateInferior,
+            3 => crate::api::sensus_bridge::VisionGlaucomaMode::Biarcuate,
+            _ => unreachable!("Invalid variant for VisionGlaucomaMode: {}", self),
         }
     }
 }
@@ -282,15 +280,163 @@ impl SseDecode for () {
 impl SseDecode for crate::api::sensus_bridge::VisionFilter {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::sensus_bridge::VisionFilter::Protanopia;
+            }
+            1 => {
+                return crate::api::sensus_bridge::VisionFilter::Deuteranopia;
+            }
+            2 => {
+                return crate::api::sensus_bridge::VisionFilter::Tritanopia;
+            }
+            3 => {
+                return crate::api::sensus_bridge::VisionFilter::Achromatopsia;
+            }
+            4 => {
+                return crate::api::sensus_bridge::VisionFilter::Tetrachromacy;
+            }
+            5 => {
+                return crate::api::sensus_bridge::VisionFilter::Myopia;
+            }
+            6 => {
+                return crate::api::sensus_bridge::VisionFilter::Hyperopia;
+            }
+            7 => {
+                return crate::api::sensus_bridge::VisionFilter::Presbyopia;
+            }
+            8 => {
+                let mut var_axisDeg = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Astigmatism {
+                    axis_deg: var_axisDeg,
+                };
+            }
+            9 => {
+                let mut var_mode =
+                    <crate::api::sensus_bridge::VisionGlaucomaMode>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Glaucoma { mode: var_mode };
+            }
+            10 => {
+                return crate::api::sensus_bridge::VisionFilter::MacularDegeneration;
+            }
+            11 => {
+                let mut var_side = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Hemianopia { side: var_side };
+            }
+            12 => {
+                return crate::api::sensus_bridge::VisionFilter::TunnelVision;
+            }
+            13 => {
+                let mut var_seed = <u64>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Cataract { seed: var_seed };
+            }
+            14 => {
+                let mut var_seed = <u64>::sse_decode(deserializer);
+                let mut var_density = <f32>::sse_decode(deserializer);
+                let mut var_size = <f32>::sse_decode(deserializer);
+                let mut var_gazeX = <f32>::sse_decode(deserializer);
+                let mut var_gazeY = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Floaters {
+                    seed: var_seed,
+                    density: var_density,
+                    size: var_size,
+                    gaze_x: var_gazeX,
+                    gaze_y: var_gazeY,
+                };
+            }
+            15 => {
+                return crate::api::sensus_bridge::VisionFilter::Photophobia;
+            }
+            16 => {
+                return crate::api::sensus_bridge::VisionFilter::NightBlindness;
+            }
+            17 => {
+                return crate::api::sensus_bridge::VisionFilter::Vertigo;
+            }
+            18 => {
+                return crate::api::sensus_bridge::VisionFilter::BppvRotation;
+            }
+            19 => {
+                return crate::api::sensus_bridge::VisionFilter::VestibularNeuritis;
+            }
+            20 => {
+                let mut var_offsetX = <f32>::sse_decode(deserializer);
+                let mut var_offsetY = <f32>::sse_decode(deserializer);
+                let mut var_ghostStrength = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Diplopia {
+                    offset_x: var_offsetX,
+                    offset_y: var_offsetY,
+                    ghost_strength: var_ghostStrength,
+                };
+            }
+            21 => {
+                let mut var_amplitude = <f32>::sse_decode(deserializer);
+                let mut var_directionDeg = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Nystagmus {
+                    amplitude: var_amplitude,
+                    direction_deg: var_directionDeg,
+                };
+            }
+            22 => {
+                let mut var_numRays = <u32>::sse_decode(deserializer);
+                let mut var_rayLengthRatio = <f32>::sse_decode(deserializer);
+                let mut var_threshold = <f32>::sse_decode(deserializer);
+                let mut var_dispersion = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Starbursts {
+                    num_rays: var_numRays,
+                    ray_length_ratio: var_rayLengthRatio,
+                    threshold: var_threshold,
+                    dispersion: var_dispersion,
+                };
+            }
+            23 => {
+                return crate::api::sensus_bridge::VisionFilter::EyeStrain;
+            }
+            24 => {
+                return crate::api::sensus_bridge::VisionFilter::DryEye;
+            }
+            25 => {
+                let mut var_freq = <f32>::sse_decode(deserializer);
+                let mut var_seed = <u64>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::Metamorphopsia {
+                    freq: var_freq,
+                    seed: var_seed,
+                };
+            }
+            26 => {
+                return crate::api::sensus_bridge::VisionFilter::ContrastSensitivity;
+            }
+            27 => {
+                let mut var_cellSize = <u32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::DetailLoss {
+                    cell_size: var_cellSize,
+                };
+            }
+            28 => {
+                return crate::api::sensus_bridge::VisionFilter::Teichopsia;
+            }
+            29 => {
+                let mut var_seed = <u64>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::VisionFilter::FlickeringStars { seed: var_seed };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseDecode for crate::api::sensus_bridge::VisionGlaucomaMode {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <i32>::sse_decode(deserializer);
         return match inner {
-            0 => crate::api::sensus_bridge::VisionFilter::Protanopia,
-            1 => crate::api::sensus_bridge::VisionFilter::Deuteranopia,
-            2 => crate::api::sensus_bridge::VisionFilter::Tritanopia,
-            3 => crate::api::sensus_bridge::VisionFilter::Achromatopsia,
-            4 => crate::api::sensus_bridge::VisionFilter::Myopia,
-            5 => crate::api::sensus_bridge::VisionFilter::Photophobia,
-            _ => unreachable!("Invalid variant for VisionFilter: {}", inner),
+            0 => crate::api::sensus_bridge::VisionGlaucomaMode::Vignette,
+            1 => crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateSuperior,
+            2 => crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateInferior,
+            3 => crate::api::sensus_bridge::VisionGlaucomaMode::Biarcuate,
+            _ => unreachable!("Invalid variant for VisionGlaucomaMode: {}", inner),
         };
     }
 }
@@ -333,13 +479,106 @@ fn pde_ffi_dispatcher_sync_impl(
 impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::VisionFilter {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
-            Self::Protanopia => 0.into_dart(),
-            Self::Deuteranopia => 1.into_dart(),
-            Self::Tritanopia => 2.into_dart(),
-            Self::Achromatopsia => 3.into_dart(),
-            Self::Myopia => 4.into_dart(),
-            Self::Photophobia => 5.into_dart(),
-            _ => unreachable!(),
+            crate::api::sensus_bridge::VisionFilter::Protanopia => [0.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Deuteranopia => [1.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Tritanopia => [2.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Achromatopsia => [3.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Tetrachromacy => [4.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Myopia => [5.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Hyperopia => [6.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Presbyopia => [7.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Astigmatism { axis_deg } => {
+                [8.into_dart(), axis_deg.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::Glaucoma { mode } => {
+                [9.into_dart(), mode.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::MacularDegeneration => {
+                [10.into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::Hemianopia { side } => {
+                [11.into_dart(), side.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::TunnelVision => [12.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Cataract { seed } => {
+                [13.into_dart(), seed.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            } => [
+                14.into_dart(),
+                seed.into_into_dart().into_dart(),
+                density.into_into_dart().into_dart(),
+                size.into_into_dart().into_dart(),
+                gaze_x.into_into_dart().into_dart(),
+                gaze_y.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Photophobia => [15.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::NightBlindness => [16.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Vertigo => [17.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::BppvRotation => [18.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::VestibularNeuritis => {
+                [19.into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            } => [
+                20.into_dart(),
+                offset_x.into_into_dart().into_dart(),
+                offset_y.into_into_dart().into_dart(),
+                ghost_strength.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Nystagmus {
+                amplitude,
+                direction_deg,
+            } => [
+                21.into_dart(),
+                amplitude.into_into_dart().into_dart(),
+                direction_deg.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            } => [
+                22.into_dart(),
+                num_rays.into_into_dart().into_dart(),
+                ray_length_ratio.into_into_dart().into_dart(),
+                threshold.into_into_dart().into_dart(),
+                dispersion.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::sensus_bridge::VisionFilter::EyeStrain => [23.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::DryEye => [24.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::Metamorphopsia { freq, seed } => [
+                25.into_dart(),
+                freq.into_into_dart().into_dart(),
+                seed.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            crate::api::sensus_bridge::VisionFilter::ContrastSensitivity => {
+                [26.into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::DetailLoss { cell_size } => {
+                [27.into_dart(), cell_size.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::VisionFilter::Teichopsia => [28.into_dart()].into_dart(),
+            crate::api::sensus_bridge::VisionFilter::FlickeringStars { seed } => {
+                [29.into_dart(), seed.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
         }
     }
 }
@@ -351,6 +590,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sensus_bridge::VisionFilter>
     for crate::api::sensus_bridge::VisionFilter
 {
     fn into_into_dart(self) -> crate::api::sensus_bridge::VisionFilter {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::VisionGlaucomaMode {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Vignette => 0.into_dart(),
+            Self::ArcuateSuperior => 1.into_dart(),
+            Self::ArcuateInferior => 2.into_dart(),
+            Self::Biarcuate => 3.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sensus_bridge::VisionGlaucomaMode
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sensus_bridge::VisionGlaucomaMode>
+    for crate::api::sensus_bridge::VisionGlaucomaMode
+{
+    fn into_into_dart(self) -> crate::api::sensus_bridge::VisionGlaucomaMode {
         self
     }
 }
@@ -435,14 +697,153 @@ impl SseEncode for () {
 impl SseEncode for crate::api::sensus_bridge::VisionFilter {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::sensus_bridge::VisionFilter::Protanopia => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Deuteranopia => {
+                <i32>::sse_encode(1, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Tritanopia => {
+                <i32>::sse_encode(2, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Achromatopsia => {
+                <i32>::sse_encode(3, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Tetrachromacy => {
+                <i32>::sse_encode(4, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Myopia => {
+                <i32>::sse_encode(5, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Hyperopia => {
+                <i32>::sse_encode(6, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Presbyopia => {
+                <i32>::sse_encode(7, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Astigmatism { axis_deg } => {
+                <i32>::sse_encode(8, serializer);
+                <f32>::sse_encode(axis_deg, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Glaucoma { mode } => {
+                <i32>::sse_encode(9, serializer);
+                <crate::api::sensus_bridge::VisionGlaucomaMode>::sse_encode(mode, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::MacularDegeneration => {
+                <i32>::sse_encode(10, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Hemianopia { side } => {
+                <i32>::sse_encode(11, serializer);
+                <f32>::sse_encode(side, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::TunnelVision => {
+                <i32>::sse_encode(12, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Cataract { seed } => {
+                <i32>::sse_encode(13, serializer);
+                <u64>::sse_encode(seed, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            } => {
+                <i32>::sse_encode(14, serializer);
+                <u64>::sse_encode(seed, serializer);
+                <f32>::sse_encode(density, serializer);
+                <f32>::sse_encode(size, serializer);
+                <f32>::sse_encode(gaze_x, serializer);
+                <f32>::sse_encode(gaze_y, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Photophobia => {
+                <i32>::sse_encode(15, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::NightBlindness => {
+                <i32>::sse_encode(16, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Vertigo => {
+                <i32>::sse_encode(17, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::BppvRotation => {
+                <i32>::sse_encode(18, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::VestibularNeuritis => {
+                <i32>::sse_encode(19, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            } => {
+                <i32>::sse_encode(20, serializer);
+                <f32>::sse_encode(offset_x, serializer);
+                <f32>::sse_encode(offset_y, serializer);
+                <f32>::sse_encode(ghost_strength, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Nystagmus {
+                amplitude,
+                direction_deg,
+            } => {
+                <i32>::sse_encode(21, serializer);
+                <f32>::sse_encode(amplitude, serializer);
+                <f32>::sse_encode(direction_deg, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            } => {
+                <i32>::sse_encode(22, serializer);
+                <u32>::sse_encode(num_rays, serializer);
+                <f32>::sse_encode(ray_length_ratio, serializer);
+                <f32>::sse_encode(threshold, serializer);
+                <f32>::sse_encode(dispersion, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::EyeStrain => {
+                <i32>::sse_encode(23, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::DryEye => {
+                <i32>::sse_encode(24, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Metamorphopsia { freq, seed } => {
+                <i32>::sse_encode(25, serializer);
+                <f32>::sse_encode(freq, serializer);
+                <u64>::sse_encode(seed, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::ContrastSensitivity => {
+                <i32>::sse_encode(26, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::DetailLoss { cell_size } => {
+                <i32>::sse_encode(27, serializer);
+                <u32>::sse_encode(cell_size, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::Teichopsia => {
+                <i32>::sse_encode(28, serializer);
+            }
+            crate::api::sensus_bridge::VisionFilter::FlickeringStars { seed } => {
+                <i32>::sse_encode(29, serializer);
+                <u64>::sse_encode(seed, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
+impl SseEncode for crate::api::sensus_bridge::VisionGlaucomaMode {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(
             match self {
-                crate::api::sensus_bridge::VisionFilter::Protanopia => 0,
-                crate::api::sensus_bridge::VisionFilter::Deuteranopia => 1,
-                crate::api::sensus_bridge::VisionFilter::Tritanopia => 2,
-                crate::api::sensus_bridge::VisionFilter::Achromatopsia => 3,
-                crate::api::sensus_bridge::VisionFilter::Myopia => 4,
-                crate::api::sensus_bridge::VisionFilter::Photophobia => 5,
+                crate::api::sensus_bridge::VisionGlaucomaMode::Vignette => 0,
+                crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateSuperior => 1,
+                crate::api::sensus_bridge::VisionGlaucomaMode::ArcuateInferior => 2,
+                crate::api::sensus_bridge::VisionGlaucomaMode::Biarcuate => 3,
                 _ => {
                     unimplemented!("");
                 }
@@ -486,6 +887,13 @@ mod io {
             String::from_utf8(vec).unwrap()
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::VisionFilter> for *mut wire_cst_vision_filter {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::api::sensus_bridge::VisionFilter>::cst_decode(*wrap).into()
+        }
+    }
     impl CstDecode<Vec<String>> for *mut wire_cst_list_String {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<String> {
@@ -523,10 +931,127 @@ mod io {
             }
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::VisionFilter> for wire_cst_vision_filter {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
+            match self.tag {
+                0 => crate::api::sensus_bridge::VisionFilter::Protanopia,
+                1 => crate::api::sensus_bridge::VisionFilter::Deuteranopia,
+                2 => crate::api::sensus_bridge::VisionFilter::Tritanopia,
+                3 => crate::api::sensus_bridge::VisionFilter::Achromatopsia,
+                4 => crate::api::sensus_bridge::VisionFilter::Tetrachromacy,
+                5 => crate::api::sensus_bridge::VisionFilter::Myopia,
+                6 => crate::api::sensus_bridge::VisionFilter::Hyperopia,
+                7 => crate::api::sensus_bridge::VisionFilter::Presbyopia,
+                8 => {
+                    let ans = unsafe { self.kind.Astigmatism };
+                    crate::api::sensus_bridge::VisionFilter::Astigmatism {
+                        axis_deg: ans.axis_deg.cst_decode(),
+                    }
+                }
+                9 => {
+                    let ans = unsafe { self.kind.Glaucoma };
+                    crate::api::sensus_bridge::VisionFilter::Glaucoma {
+                        mode: ans.mode.cst_decode(),
+                    }
+                }
+                10 => crate::api::sensus_bridge::VisionFilter::MacularDegeneration,
+                11 => {
+                    let ans = unsafe { self.kind.Hemianopia };
+                    crate::api::sensus_bridge::VisionFilter::Hemianopia {
+                        side: ans.side.cst_decode(),
+                    }
+                }
+                12 => crate::api::sensus_bridge::VisionFilter::TunnelVision,
+                13 => {
+                    let ans = unsafe { self.kind.Cataract };
+                    crate::api::sensus_bridge::VisionFilter::Cataract {
+                        seed: ans.seed.cst_decode(),
+                    }
+                }
+                14 => {
+                    let ans = unsafe { self.kind.Floaters };
+                    crate::api::sensus_bridge::VisionFilter::Floaters {
+                        seed: ans.seed.cst_decode(),
+                        density: ans.density.cst_decode(),
+                        size: ans.size.cst_decode(),
+                        gaze_x: ans.gaze_x.cst_decode(),
+                        gaze_y: ans.gaze_y.cst_decode(),
+                    }
+                }
+                15 => crate::api::sensus_bridge::VisionFilter::Photophobia,
+                16 => crate::api::sensus_bridge::VisionFilter::NightBlindness,
+                17 => crate::api::sensus_bridge::VisionFilter::Vertigo,
+                18 => crate::api::sensus_bridge::VisionFilter::BppvRotation,
+                19 => crate::api::sensus_bridge::VisionFilter::VestibularNeuritis,
+                20 => {
+                    let ans = unsafe { self.kind.Diplopia };
+                    crate::api::sensus_bridge::VisionFilter::Diplopia {
+                        offset_x: ans.offset_x.cst_decode(),
+                        offset_y: ans.offset_y.cst_decode(),
+                        ghost_strength: ans.ghost_strength.cst_decode(),
+                    }
+                }
+                21 => {
+                    let ans = unsafe { self.kind.Nystagmus };
+                    crate::api::sensus_bridge::VisionFilter::Nystagmus {
+                        amplitude: ans.amplitude.cst_decode(),
+                        direction_deg: ans.direction_deg.cst_decode(),
+                    }
+                }
+                22 => {
+                    let ans = unsafe { self.kind.Starbursts };
+                    crate::api::sensus_bridge::VisionFilter::Starbursts {
+                        num_rays: ans.num_rays.cst_decode(),
+                        ray_length_ratio: ans.ray_length_ratio.cst_decode(),
+                        threshold: ans.threshold.cst_decode(),
+                        dispersion: ans.dispersion.cst_decode(),
+                    }
+                }
+                23 => crate::api::sensus_bridge::VisionFilter::EyeStrain,
+                24 => crate::api::sensus_bridge::VisionFilter::DryEye,
+                25 => {
+                    let ans = unsafe { self.kind.Metamorphopsia };
+                    crate::api::sensus_bridge::VisionFilter::Metamorphopsia {
+                        freq: ans.freq.cst_decode(),
+                        seed: ans.seed.cst_decode(),
+                    }
+                }
+                26 => crate::api::sensus_bridge::VisionFilter::ContrastSensitivity,
+                27 => {
+                    let ans = unsafe { self.kind.DetailLoss };
+                    crate::api::sensus_bridge::VisionFilter::DetailLoss {
+                        cell_size: ans.cell_size.cst_decode(),
+                    }
+                }
+                28 => crate::api::sensus_bridge::VisionFilter::Teichopsia,
+                29 => {
+                    let ans = unsafe { self.kind.FlickeringStars };
+                    crate::api::sensus_bridge::VisionFilter::FlickeringStars {
+                        seed: ans.seed.cst_decode(),
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+    impl NewWithNullPtr for wire_cst_vision_filter {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: VisionFilterKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_vision_filter {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
-        filter: i32,
+        filter: *mut wire_cst_vision_filter,
         rgba8: *mut wire_cst_list_prim_u_8_loose,
         width: u32,
         height: u32,
@@ -539,28 +1064,34 @@ mod io {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_shader_glsl(
-        filter: i32,
+        filter: *mut wire_cst_vision_filter,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
         wire__crate__api__sensus_bridge__vision_shader_glsl_impl(filter)
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_uniform_layout(
-        filter: i32,
+        filter: *mut wire_cst_vision_filter,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
         wire__crate__api__sensus_bridge__vision_uniform_layout_impl(filter)
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_uniforms(
-        filter: i32,
+        filter: *mut wire_cst_vision_filter,
         strength: f32,
+        time: f32,
         width: u32,
         height: u32,
-        _seed: u64,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-        wire__crate__api__sensus_bridge__vision_uniforms_impl(
-            filter, strength, width, height, _seed,
+        wire__crate__api__sensus_bridge__vision_uniforms_impl(filter, strength, time, width, height)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_universal_experience_cst_new_box_autoadd_vision_filter(
+    ) -> *mut wire_cst_vision_filter {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_vision_filter::new_with_null_ptr(),
         )
     }
 
@@ -635,6 +1166,94 @@ mod io {
         ptr: *mut u8,
         len: i32,
     }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_vision_filter {
+        tag: i32,
+        kind: VisionFilterKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union VisionFilterKind {
+        Astigmatism: wire_cst_VisionFilter_Astigmatism,
+        Glaucoma: wire_cst_VisionFilter_Glaucoma,
+        Hemianopia: wire_cst_VisionFilter_Hemianopia,
+        Cataract: wire_cst_VisionFilter_Cataract,
+        Floaters: wire_cst_VisionFilter_Floaters,
+        Diplopia: wire_cst_VisionFilter_Diplopia,
+        Nystagmus: wire_cst_VisionFilter_Nystagmus,
+        Starbursts: wire_cst_VisionFilter_Starbursts,
+        Metamorphopsia: wire_cst_VisionFilter_Metamorphopsia,
+        DetailLoss: wire_cst_VisionFilter_DetailLoss,
+        FlickeringStars: wire_cst_VisionFilter_FlickeringStars,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Astigmatism {
+        axis_deg: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Glaucoma {
+        mode: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Hemianopia {
+        side: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Cataract {
+        seed: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Floaters {
+        seed: u64,
+        density: f32,
+        size: f32,
+        gaze_x: f32,
+        gaze_y: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Diplopia {
+        offset_x: f32,
+        offset_y: f32,
+        ghost_strength: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Nystagmus {
+        amplitude: f32,
+        direction_deg: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Starbursts {
+        num_rays: u32,
+        ray_length_ratio: f32,
+        threshold: f32,
+        dispersion: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_Metamorphopsia {
+        freq: f32,
+        seed: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_DetailLoss {
+        cell_size: u32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_VisionFilter_FlickeringStars {
+        seed: u64,
+    }
 }
 #[cfg(not(target_family = "wasm"))]
 pub use io::*;
@@ -690,6 +1309,80 @@ mod web {
             self.into_vec()
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::VisionFilter>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
+            let self_ = self.unchecked_into::<flutter_rust_bridge::for_generated::js_sys::Array>();
+            match self_.get(0).unchecked_into_f64() as _ {
+                0 => crate::api::sensus_bridge::VisionFilter::Protanopia,
+                1 => crate::api::sensus_bridge::VisionFilter::Deuteranopia,
+                2 => crate::api::sensus_bridge::VisionFilter::Tritanopia,
+                3 => crate::api::sensus_bridge::VisionFilter::Achromatopsia,
+                4 => crate::api::sensus_bridge::VisionFilter::Tetrachromacy,
+                5 => crate::api::sensus_bridge::VisionFilter::Myopia,
+                6 => crate::api::sensus_bridge::VisionFilter::Hyperopia,
+                7 => crate::api::sensus_bridge::VisionFilter::Presbyopia,
+                8 => crate::api::sensus_bridge::VisionFilter::Astigmatism {
+                    axis_deg: self_.get(1).cst_decode(),
+                },
+                9 => crate::api::sensus_bridge::VisionFilter::Glaucoma {
+                    mode: self_.get(1).cst_decode(),
+                },
+                10 => crate::api::sensus_bridge::VisionFilter::MacularDegeneration,
+                11 => crate::api::sensus_bridge::VisionFilter::Hemianopia {
+                    side: self_.get(1).cst_decode(),
+                },
+                12 => crate::api::sensus_bridge::VisionFilter::TunnelVision,
+                13 => crate::api::sensus_bridge::VisionFilter::Cataract {
+                    seed: self_.get(1).cst_decode(),
+                },
+                14 => crate::api::sensus_bridge::VisionFilter::Floaters {
+                    seed: self_.get(1).cst_decode(),
+                    density: self_.get(2).cst_decode(),
+                    size: self_.get(3).cst_decode(),
+                    gaze_x: self_.get(4).cst_decode(),
+                    gaze_y: self_.get(5).cst_decode(),
+                },
+                15 => crate::api::sensus_bridge::VisionFilter::Photophobia,
+                16 => crate::api::sensus_bridge::VisionFilter::NightBlindness,
+                17 => crate::api::sensus_bridge::VisionFilter::Vertigo,
+                18 => crate::api::sensus_bridge::VisionFilter::BppvRotation,
+                19 => crate::api::sensus_bridge::VisionFilter::VestibularNeuritis,
+                20 => crate::api::sensus_bridge::VisionFilter::Diplopia {
+                    offset_x: self_.get(1).cst_decode(),
+                    offset_y: self_.get(2).cst_decode(),
+                    ghost_strength: self_.get(3).cst_decode(),
+                },
+                21 => crate::api::sensus_bridge::VisionFilter::Nystagmus {
+                    amplitude: self_.get(1).cst_decode(),
+                    direction_deg: self_.get(2).cst_decode(),
+                },
+                22 => crate::api::sensus_bridge::VisionFilter::Starbursts {
+                    num_rays: self_.get(1).cst_decode(),
+                    ray_length_ratio: self_.get(2).cst_decode(),
+                    threshold: self_.get(3).cst_decode(),
+                    dispersion: self_.get(4).cst_decode(),
+                },
+                23 => crate::api::sensus_bridge::VisionFilter::EyeStrain,
+                24 => crate::api::sensus_bridge::VisionFilter::DryEye,
+                25 => crate::api::sensus_bridge::VisionFilter::Metamorphopsia {
+                    freq: self_.get(1).cst_decode(),
+                    seed: self_.get(2).cst_decode(),
+                },
+                26 => crate::api::sensus_bridge::VisionFilter::ContrastSensitivity,
+                27 => crate::api::sensus_bridge::VisionFilter::DetailLoss {
+                    cell_size: self_.get(1).cst_decode(),
+                },
+                28 => crate::api::sensus_bridge::VisionFilter::Teichopsia,
+                29 => crate::api::sensus_bridge::VisionFilter::FlickeringStars {
+                    seed: self_.get(1).cst_decode(),
+                },
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<String> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> String {
@@ -742,18 +1435,18 @@ mod web {
             self.unchecked_into_f64() as _
         }
     }
-    impl CstDecode<crate::api::sensus_bridge::VisionFilter>
+    impl CstDecode<crate::api::sensus_bridge::VisionGlaucomaMode>
         for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
     {
         // Codec=Cst (C-struct based), see doc to use other codecs
-        fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
+        fn cst_decode(self) -> crate::api::sensus_bridge::VisionGlaucomaMode {
             (self.unchecked_into_f64() as i32).cst_decode()
         }
     }
 
     #[wasm_bindgen]
     pub fn wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
-        filter: i32,
+        filter: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
         rgba8: Box<[u8]>,
         width: u32,
         height: u32,
@@ -766,29 +1459,27 @@ mod web {
 
     #[wasm_bindgen]
     pub fn wire__crate__api__sensus_bridge__vision_shader_glsl(
-        filter: i32,
+        filter: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
         wire__crate__api__sensus_bridge__vision_shader_glsl_impl(filter)
     }
 
     #[wasm_bindgen]
     pub fn wire__crate__api__sensus_bridge__vision_uniform_layout(
-        filter: i32,
+        filter: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
         wire__crate__api__sensus_bridge__vision_uniform_layout_impl(filter)
     }
 
     #[wasm_bindgen]
     pub fn wire__crate__api__sensus_bridge__vision_uniforms(
-        filter: i32,
+        filter: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
         strength: f32,
+        time: f32,
         width: u32,
         height: u32,
-        _seed: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
-        wire__crate__api__sensus_bridge__vision_uniforms_impl(
-            filter, strength, width, height, _seed,
-        )
+        wire__crate__api__sensus_bridge__vision_uniforms_impl(filter, strength, time, width, height)
     }
 }
 #[cfg(target_family = "wasm")]


### PR DESCRIPTION
closes #9

## 概要
#7 の MVP ブリッジ（vision 6 種）を sensus の**全 30 vision フィルタ**へ拡張。payload 付きフィルタ（Astigmatism/Glaucoma/Hemianopia/Cataract/Floaters/Diplopia/Nystagmus/Starbursts/Metamorphopsia/DetailLoss/FlickeringStars）はフィールド付き enum で FRB→Dart sealed class として公開。

## 変更
- `VisionFilter` を全 vision バリアントへ拡張。`VisionGlaucomaMode` ミラー enum 追加。
- `vision_shader_glsl` / `vision_uniforms`（`time` 引数追加）/ `vision_uniform_layout` / `apply_vision_cpu_rgba8` を全フィルタ対応。uniform flat 配列は各 `.frag` の宣言順に厳密一致。
- 全フィルタに sensus の `*_glsl()`/`*_uniforms()` が実在することを確認（非対応分岐は不要）。Vertigo/BppvRotation のみ time 反映。
- payload の非有限値（NaN/Inf）を bridge 出口で 0.0 に丸める防御ガード。
- FRB codegen 再生成（freezed 2.x で payload sealed class 生成）、Dart バインディング更新。
- テスト 20 件（全フィルタ layout==uniforms長 / time 依存・非依存 / 0次元 / NaN payload fuzz / CPU apply サイズ）。

## 検証
- `cargo build`（統合）/ `cargo test` 20 passed / `cargo fmt --check` / `cargo clippy --all-targets -D warnings` 0
- `flutter_rust_bridge_codegen generate` 成功 / `dart run build_runner build` / `flutter analyze` エラー0
- ⚠️ 実機 `flutter run` は Linux desktop toolchain 未導入のため未検証（描画は #11）。

## セルフレビュー
Approve。should（payload 非 sanitize）+ nit 2 を全件修正・再検証済み。