### PR TITLE
feat: Material3 テーマ + before/after 比較 + 設定永続化 (#17)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'dart:io' show Platform;
 
 import 'services/filter_service.dart';
 import 'services/loupe_window_controller.dart';
+import 'services/settings_service.dart';
 import 'ui/screens/home_screen.dart';
 import 'ui/theme/app_theme.dart';
 
@@ -15,6 +16,12 @@ final LoupeWindowController loupeWindow = LoupeWindowController();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Restore persisted settings (theme mode / last filter / intensity) before
+  // building the app so the first frame already reflects the user's choices
+  // (#17, settings_service.dart).
+  final settings = SettingsService();
+  await settings.load();
 
   // Initialize window manager for desktop platforms
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
@@ -54,25 +61,41 @@ void main() async {
     });
   }
 
-  runApp(const UniversalExperienceApp());
+  runApp(UniversalExperienceApp(settings: settings));
 }
 
 class UniversalExperienceApp extends StatelessWidget {
-  const UniversalExperienceApp({super.key});
+  const UniversalExperienceApp({super.key, required this.settings});
+
+  /// Pre-loaded settings service (theme mode / last filter / intensity).
+  final SettingsService settings;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => FilterService()),
+        // SettingsService is created+loaded in main() so the first frame uses
+        // restored values; provide the existing instance (not a fresh one).
+        ChangeNotifierProvider<SettingsService>.value(value: settings),
+        // FilterService is seeded from the restored settings so the previously
+        // selected filter + intensity are reflected on startup.
+        ChangeNotifierProvider<FilterService>(
+          create: (_) => FilterService()
+            ..applyFilter(settings.filterType, intensity: settings.intensity),
+        ),
       ],
-      child: MaterialApp(
-        title: 'Universal Experience',
-        theme: AppTheme.lightTheme,
-        darkTheme: AppTheme.darkTheme,
-        themeMode: ThemeMode.system,
-        home: const HomeScreen(),
-        debugShowCheckedModeBanner: false,
+      // Rebuild MaterialApp when the persisted theme mode changes.
+      child: Consumer<SettingsService>(
+        builder: (context, settings, _) {
+          return MaterialApp(
+            title: 'Universal Experience',
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+            themeMode: settings.themeMode,
+            home: const HomeScreen(),
+            debugShowCheckedModeBanner: false,
+          );
+        },
       ),
     );
   }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/disability_type.dart';
+
+/// Persists and restores user preferences via [SharedPreferences].
+///
+/// Owns three persisted settings:
+/// - [themeMode]   ([ThemeMode], light/dark/system)
+/// - [filterType]  (the last selected [ColorVisionType])
+/// - [intensity]   (the last filter intensity, 0.0..1.0)
+///
+/// The service is a [ChangeNotifier] so widgets (e.g. the [MaterialApp] theme)
+/// rebuild when settings change. Call [load] once at startup before runApp to
+/// hydrate the in-memory state from disk.
+class SettingsService extends ChangeNotifier {
+  SettingsService({SharedPreferences? prefs}) : _prefs = prefs;
+
+  // Persistence keys.
+  static const String keyThemeMode = 'settings.themeMode';
+  static const String keyFilterType = 'settings.filterType';
+  static const String keyIntensity = 'settings.intensity';
+
+  SharedPreferences? _prefs;
+
+  ThemeMode _themeMode = ThemeMode.system;
+  ColorVisionType _filterType = ColorVisionType.none;
+  double _intensity = 1.0;
+
+  ThemeMode get themeMode => _themeMode;
+  ColorVisionType get filterType => _filterType;
+  double get intensity => _intensity;
+
+  /// Loads persisted settings from disk into memory.
+  ///
+  /// Safe to call when nothing has been saved yet: defaults are kept.
+  Future<void> load() async {
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+
+    final themeName = prefs.getString(keyThemeMode);
+    if (themeName != null) {
+      _themeMode = _themeModeFromName(themeName);
+    }
+
+    final filterName = prefs.getString(keyFilterType);
+    if (filterName != null) {
+      _filterType = _filterTypeFromName(filterName);
+    }
+
+    final storedIntensity = prefs.getDouble(keyIntensity);
+    if (storedIntensity != null) {
+      _intensity = storedIntensity.clamp(0.0, 1.0);
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (mode == _themeMode) return;
+    _themeMode = mode;
+    notifyListeners();
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setString(keyThemeMode, mode.name);
+  }
+
+  Future<void> setFilterType(ColorVisionType type) async {
+    if (type == _filterType) return;
+    _filterType = type;
+    notifyListeners();
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setString(keyFilterType, type.name);
+  }
+
+  Future<void> setIntensity(double value) async {
+    final clamped = value.clamp(0.0, 1.0);
+    if (clamped == _intensity) return;
+    _intensity = clamped;
+    notifyListeners();
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setDouble(keyIntensity, clamped);
+  }
+
+  static ThemeMode _themeModeFromName(String name) {
+    return ThemeMode.values.firstWhere(
+      (m) => m.name == name,
+      orElse: () => ThemeMode.system,
+    );
+  }
+
+  static ColorVisionType _filterTypeFromName(String name) {
+    return ColorVisionType.values.firstWhere(
+      (t) => t.name == name,
+      orElse: () => ColorVisionType.none,
+    );
+  }
+}

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -2,11 +2,47 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/disability_type.dart';
 import '../../services/filter_service.dart';
+import '../../services/settings_service.dart';
+import '../widgets/before_after_view.dart';
 import '../widgets/filter_selector.dart';
 import '../widgets/intensity_slider.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  FilterService? _filterService;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Bridge FilterService selection/intensity changes into SettingsService so
+    // the last filter + intensity are persisted (#17). Subscribe once.
+    final filterService = context.read<FilterService>();
+    if (!identical(filterService, _filterService)) {
+      _filterService?.removeListener(_persistFilterState);
+      _filterService = filterService;
+      _filterService!.addListener(_persistFilterState);
+    }
+  }
+
+  void _persistFilterState() {
+    final settings = context.read<SettingsService>();
+    final filterService = _filterService;
+    if (filterService == null) return;
+    settings.setFilterType(filterService.currentFilter);
+    settings.setIntensity(filterService.intensity);
+  }
+
+  @override
+  void dispose() {
+    _filterService?.removeListener(_persistFilterState);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -14,6 +50,7 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Universal Experience'),
         actions: [
+          const _ThemeModeButton(),
           IconButton(
             icon: const Icon(Icons.info_outline),
             onPressed: () => _showAboutDialog(context),
@@ -32,6 +69,8 @@ class HomeScreen extends StatelessWidget {
               _buildFilterSection(),
               const SizedBox(height: 24),
               _buildControlsSection(),
+              const SizedBox(height: 24),
+              _buildPreviewSection(),
               const SizedBox(height: 32),
               _buildInfoSection(),
             ],
@@ -131,6 +170,52 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
+  Widget _buildPreviewSection() {
+    return Consumer<FilterService>(
+      builder: (context, filterService, _) {
+        final theme = Theme.of(context);
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.compare, color: theme.colorScheme.primary),
+                    const SizedBox(width: 12),
+                    Text(
+                      'Before / After',
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                BeforeAfterView(
+                  filterType: filterService.currentFilter,
+                  intensity: filterService.intensity,
+                ),
+                if (!BeforeAfterView.canRender(filterService.currentFilter)) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    'Live rendering for this filter is not implemented yet — '
+                    'only protanopia/protanomaly are drawn today.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontStyle: FontStyle.italic,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   Widget _buildInfoSection() {
     return Consumer<FilterService>(
       builder: (context, filterService, _) {
@@ -208,4 +293,35 @@ class HomeScreen extends StatelessWidget {
       ],
     );
   }
+}
+
+/// AppBar action that cycles the persisted theme mode (system → light → dark →
+/// system) and shows the current mode's icon. Writes through to
+/// [SettingsService] so the choice survives restarts (#17).
+class _ThemeModeButton extends StatelessWidget {
+  const _ThemeModeButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<SettingsService>(
+      builder: (context, settings, _) {
+        final (IconData icon, String tooltip) = switch (settings.themeMode) {
+          ThemeMode.system => (Icons.brightness_auto, 'Theme: System'),
+          ThemeMode.light => (Icons.light_mode, 'Theme: Light'),
+          ThemeMode.dark => (Icons.dark_mode, 'Theme: Dark'),
+        };
+        return IconButton(
+          icon: Icon(icon),
+          tooltip: '$tooltip (tap to change)',
+          onPressed: () => settings.setThemeMode(_next(settings.themeMode)),
+        );
+      },
+    );
+  }
+
+  ThemeMode _next(ThemeMode mode) => switch (mode) {
+        ThemeMode.system => ThemeMode.light,
+        ThemeMode.light => ThemeMode.dark,
+        ThemeMode.dark => ThemeMode.system,
+      };
 }

--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -1,67 +1,48 @@
 import 'package:flutter/material.dart';
 
+/// Application theming for universal-experience.
+///
+/// Material 3 themes generated from a single [seedColor] via
+/// [ColorScheme.fromSeed]. Both light and dark variants share the same seed so
+/// the brand identity stays consistent across modes.
 class AppTheme {
-  // Brand Colors
-  static const Color primaryColor = Color(0xFF6366F1); // Indigo
-  static const Color secondaryColor = Color(0xFF8B5CF6); // Purple
-  static const Color accentColor = Color(0xFF06B6D4); // Cyan
+  AppTheme._();
 
-  // Light Theme
-  static ThemeData get lightTheme {
-    return ThemeData(
-      useMaterial3: true,
-      brightness: Brightness.light,
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: primaryColor,
-        brightness: Brightness.light,
-      ),
-      appBarTheme: const AppBarTheme(
-        centerTitle: true,
-        elevation: 0,
-      ),
-      cardTheme: CardThemeData(
-        elevation: 2,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-      ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-        ),
-      ),
+  /// Brand seed color. A calm teal/cyan that reads well for an
+  /// accessibility-focused colour-vision tool.
+  static const Color seedColor = Color(0xFF00897B);
+
+  static ThemeData get lightTheme => _build(Brightness.light);
+
+  static ThemeData get darkTheme => _build(Brightness.dark);
+
+  static ThemeData _build(Brightness brightness) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: seedColor,
+      brightness: brightness,
     );
-  }
 
-  // Dark Theme
-  static ThemeData get darkTheme {
     return ThemeData(
       useMaterial3: true,
-      brightness: Brightness.dark,
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: primaryColor,
-        brightness: Brightness.dark,
-      ),
-      appBarTheme: const AppBarTheme(
-        centerTitle: true,
+      colorScheme: colorScheme,
+      brightness: brightness,
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+        centerTitle: false,
         elevation: 0,
+        scrolledUnderElevation: 2,
       ),
       cardTheme: CardThemeData(
-        elevation: 2,
+        elevation: 0,
+        color: colorScheme.surfaceContainerHighest,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
+        clipBehavior: Clip.antiAlias,
       ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-        ),
+      sliderTheme: const SliderThemeData(
+        showValueIndicator: ShowValueIndicator.onDrag,
       ),
     );
   }

--- a/lib/ui/widgets/before_after_view.dart
+++ b/lib/ui/widgets/before_after_view.dart
@@ -1,0 +1,350 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../models/disability_type.dart';
+import '../../rendering/shader_filter.dart';
+
+/// Side-by-side "before / after" preview for a colour-vision filter.
+///
+/// The *before* pane shows a generated sample image (a smooth hue gradient with
+/// primary colour swatches — chosen because colour-vision deficiencies are most
+/// visible on saturated reds/greens/blues). The *after* pane shows the same
+/// image with the selected filter applied.
+///
+/// Only [ColorVisionType.protanopia] / [ColorVisionType.protanomaly] can be
+/// rendered for real today: they route through
+/// [ShaderFilter.applyProtanopiaGpu] (the one GPU path proven by the golden
+/// test). protanomaly reuses the protanopia transform at a reduced strength
+/// ([recommendedStrength]). Every other filter shows a "rendering coming soon"
+/// placeholder, because live/GPU rendering for them is tracked by other issues
+/// (#1/#3/#4 live capture, #11 follow-ups for the remaining shaders).
+class BeforeAfterView extends StatefulWidget {
+  const BeforeAfterView({
+    super.key,
+    required this.filterType,
+    required this.intensity,
+    this.sampleSize = 256,
+  });
+
+  /// The currently selected colour-vision type. [ColorVisionType.none] shows
+  /// the original image on both sides.
+  final ColorVisionType filterType;
+
+  /// Filter strength 0.0..1.0, forwarded to the shader.
+  final double intensity;
+
+  /// Width/height in logical pixels of the generated square sample image.
+  final int sampleSize;
+
+  /// Whether [type] can currently be rendered to a real "after" image.
+  ///
+  /// Exposed as a static so tests and callers can reason about render coverage
+  /// without instantiating the widget.
+  static bool canRender(ColorVisionType type) {
+    switch (type) {
+      case ColorVisionType.none:
+      case ColorVisionType.protanopia:
+      case ColorVisionType.protanomaly:
+        return true;
+      case ColorVisionType.deuteranopia:
+      case ColorVisionType.deuteranomaly:
+      case ColorVisionType.tritanopia:
+      case ColorVisionType.tritanomaly:
+      case ColorVisionType.achromatopsia:
+        return false;
+    }
+  }
+
+  /// Builds the deterministic sample image used in the *before* pane.
+  ///
+  /// Programmatically generated (no asset dependency): a horizontal hue sweep
+  /// with a vertical brightness ramp, overlaid with red/green/blue/yellow
+  /// swatches along the bottom. Static + async so tests can obtain the same
+  /// image the widget uses.
+  static Future<ui.Image> generateSampleImage(int size) async {
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    final fSize = size.toDouble();
+
+    // Hue sweep (left→right) with brightness ramp (top→bottom).
+    const columns = 64;
+    final colW = fSize / columns;
+    for (int c = 0; c < columns; c++) {
+      final hue = (c / columns) * 360.0;
+      final color = HSVColor.fromAHSV(1.0, hue, 1.0, 1.0).toColor();
+      canvas.drawRect(
+        Rect.fromLTWH(c * colW, 0, colW + 1, fSize),
+        Paint()..color = color,
+      );
+    }
+    // Brightness ramp as a translucent black gradient over the lower half.
+    canvas.drawRect(
+      Rect.fromLTWH(0, fSize * 0.5, fSize, fSize * 0.5),
+      Paint()
+        ..shader = ui.Gradient.linear(
+          Offset(0, fSize * 0.5),
+          Offset(0, fSize),
+          const [Color(0x00000000), Color(0xCC000000)],
+        ),
+    );
+
+    // Saturated swatches along the bottom — the cases CVD distorts most.
+    const swatches = [
+      Color(0xFFE53935), // red
+      Color(0xFF43A047), // green
+      Color(0xFF1E88E5), // blue
+      Color(0xFFFDD835), // yellow
+    ];
+    final swW = fSize / swatches.length;
+    final swTop = fSize * 0.75;
+    for (int i = 0; i < swatches.length; i++) {
+      canvas.drawRect(
+        Rect.fromLTWH(i * swW, swTop, swW, fSize - swTop),
+        Paint()..color = swatches[i],
+      );
+    }
+
+    final picture = recorder.endRecording();
+    try {
+      return await picture.toImage(size, size);
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  /// Produces the *after* image for [type] from [source], or null when the
+  /// filter has no real renderer yet.
+  ///
+  /// [ColorVisionType.none] returns [source] unchanged (clone via the shader is
+  /// unnecessary). protanopia/protanomaly route through the GPU shader.
+  static Future<ui.Image?> renderAfter(
+    ui.Image source,
+    ColorVisionType type,
+    double strength,
+  ) async {
+    switch (type) {
+      case ColorVisionType.none:
+        return source;
+      case ColorVisionType.protanopia:
+      case ColorVisionType.protanomaly:
+        return ShaderFilter.applyProtanopiaGpu(source, strength);
+      case ColorVisionType.deuteranopia:
+      case ColorVisionType.deuteranomaly:
+      case ColorVisionType.tritanopia:
+      case ColorVisionType.tritanomaly:
+      case ColorVisionType.achromatopsia:
+        return null;
+    }
+  }
+
+  @override
+  State<BeforeAfterView> createState() => _BeforeAfterViewState();
+}
+
+class _BeforeAfterViewState extends State<BeforeAfterView> {
+  ui.Image? _before;
+  ui.Image? _after;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuild();
+  }
+
+  @override
+  void didUpdateWidget(BeforeAfterView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.filterType != widget.filterType ||
+        oldWidget.intensity != widget.intensity ||
+        oldWidget.sampleSize != widget.sampleSize) {
+      _rebuild();
+    }
+  }
+
+  Future<void> _rebuild() async {
+    setState(() => _loading = true);
+    final before =
+        _before ?? await BeforeAfterView.generateSampleImage(widget.sampleSize);
+    final after = await BeforeAfterView.renderAfter(
+      before,
+      widget.filterType,
+      widget.intensity,
+    );
+    if (!mounted) return;
+    setState(() {
+      _before = before;
+      _after = after;
+      _loading = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _before?.dispose();
+    // _after may alias _before (when filterType == none); avoid double dispose.
+    if (!identical(_after, _before)) {
+      _after?.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (_loading && _before == null) {
+      return const SizedBox(
+        height: 180,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Stack the two panes vertically on narrow widths.
+        final stackVertically = constraints.maxWidth < 420;
+        final beforePane = _Pane(
+          label: 'Original',
+          child: _ImageView(image: _before),
+        );
+        final afterPane = _Pane(
+          label: widget.filterType == ColorVisionType.none
+              ? 'Original'
+              : widget.filterType.displayName,
+          child: _after != null
+              ? _ImageView(image: _after)
+              : _ComingSoonPlaceholder(theme: theme),
+        );
+
+        if (stackVertically) {
+          return Column(
+            children: [
+              beforePane,
+              const SizedBox(height: 12),
+              afterPane,
+            ],
+          );
+        }
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: beforePane),
+            const SizedBox(width: 12),
+            Expanded(child: afterPane),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _Pane extends StatelessWidget {
+  const _Pane({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(label, style: theme.textTheme.labelLarge),
+        const SizedBox(height: 6),
+        AspectRatio(
+          aspectRatio: 1,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: child,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ImageView extends StatelessWidget {
+  const _ImageView({required this.image});
+
+  final ui.Image? image;
+
+  @override
+  Widget build(BuildContext context) {
+    final img = image;
+    if (img == null) {
+      return const ColoredBox(color: Color(0x11000000));
+    }
+    return CustomPaint(
+      painter: _UiImagePainter(img),
+      size: Size.infinite,
+    );
+  }
+}
+
+class _UiImagePainter extends CustomPainter {
+  _UiImagePainter(this.image);
+
+  final ui.Image image;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final src = Rect.fromLTWH(
+      0,
+      0,
+      image.width.toDouble(),
+      image.height.toDouble(),
+    );
+    final dst = Rect.fromLTWH(0, 0, size.width, size.height);
+    canvas.drawImageRect(image, src, dst, Paint());
+  }
+
+  @override
+  bool shouldRepaint(_UiImagePainter oldDelegate) =>
+      !identical(oldDelegate.image, image);
+}
+
+class _ComingSoonPlaceholder extends StatelessWidget {
+  const _ComingSoonPlaceholder({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.brush_outlined,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Rendering coming soon',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Encodes a [ui.Image] to PNG bytes. Helper kept here so tests can assert the
+/// rendered "after" image is non-empty without depending on widget internals.
+Future<Uint8List?> encodeImagePng(ui.Image image) async {
+  final data = await image.toByteData(format: ui.ImageByteFormat.png);
+  return data?.buffer.asUint8List();
+}

--- a/lib/ui/widgets/before_after_view.dart
+++ b/lib/ui/widgets/before_after_view.dart
@@ -195,9 +195,19 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     if (_loading && _before == null) {
-      return const SizedBox(
+      // Non-animating placeholder while the first sample image is generated.
+      // (A CircularProgressIndicator would animate forever and block
+      // pumpAndSettle in widget tests.)
+      return SizedBox(
         height: 180,
-        child: Center(child: CircularProgressIndicator()),
+        child: Center(
+          child: Text(
+            'Preparing preview…',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
       );
     }
 

--- a/test/before_after_view_test.dart
+++ b/test/before_after_view_test.dart
@@ -1,0 +1,146 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_experience/models/disability_type.dart';
+import 'package:universal_experience/ui/widgets/before_after_view.dart';
+
+/// BeforeAfterView の before/after 生成ロジックと描画カバレッジのテスト（#17）。
+///
+/// 静的ヘルパ（generateSampleImage / renderAfter / canRender）を直接検証する。
+/// protanopia は ShaderFilter 経由で実描画でき、他フィルタは未描画
+/// （null = プレースホルダ表示）であることを確認する。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('canRender 描画カバレッジ', () {
+    test('protanopia / protanomaly / none は描画可能', () {
+      expect(BeforeAfterView.canRender(ColorVisionType.none), isTrue);
+      expect(BeforeAfterView.canRender(ColorVisionType.protanopia), isTrue);
+      expect(BeforeAfterView.canRender(ColorVisionType.protanomaly), isTrue);
+    });
+
+    test('未実装フィルタは描画不可（プレースホルダ）', () {
+      expect(BeforeAfterView.canRender(ColorVisionType.deuteranopia), isFalse);
+      expect(BeforeAfterView.canRender(ColorVisionType.tritanopia), isFalse);
+      expect(BeforeAfterView.canRender(ColorVisionType.achromatopsia), isFalse);
+      expect(BeforeAfterView.canRender(ColorVisionType.deuteranomaly), isFalse);
+      expect(BeforeAfterView.canRender(ColorVisionType.tritanomaly), isFalse);
+    });
+  });
+
+  group('generateSampleImage', () {
+    test('指定サイズの正方形画像を生成し PNG 化できる', () async {
+      final img = await BeforeAfterView.generateSampleImage(64);
+      expect(img.width, 64);
+      expect(img.height, 64);
+      final png = await encodeImagePng(img);
+      expect(png, isNotNull);
+      expect(png!.isNotEmpty, isTrue);
+      img.dispose();
+    });
+  });
+
+  group('renderAfter', () {
+    late ui.Image src;
+
+    setUp(() async {
+      src = await BeforeAfterView.generateSampleImage(64);
+    });
+
+    tearDown(() {
+      src.dispose();
+    });
+
+    test('none は元画像をそのまま返す', () async {
+      final out = await BeforeAfterView.renderAfter(
+        src,
+        ColorVisionType.none,
+        1.0,
+      );
+      expect(identical(out, src), isTrue);
+    });
+
+    test('protanopia は GPU 実描画で after 画像を生成する', () async {
+      final out = await BeforeAfterView.renderAfter(
+        src,
+        ColorVisionType.protanopia,
+        1.0,
+      );
+      expect(out, isNotNull);
+      expect(out!.width, 64);
+      expect(out.height, 64);
+
+      // after が原画と異なる（実際にフィルタが効いている）ことを確認。
+      final beforePng = await encodeImagePng(src);
+      final afterPng = await encodeImagePng(out);
+      expect(beforePng, isNotNull);
+      expect(afterPng, isNotNull);
+      expect(afterPng, isNot(equals(beforePng)));
+      out.dispose();
+    });
+
+    test('protanomaly も protanopia 経路で描画できる', () async {
+      final out = await BeforeAfterView.renderAfter(
+        src,
+        ColorVisionType.protanomaly,
+        0.6,
+      );
+      expect(out, isNotNull);
+      out!.dispose();
+    });
+
+    test('未実装フィルタは null（プレースホルダ）を返す', () async {
+      for (final type in [
+        ColorVisionType.deuteranopia,
+        ColorVisionType.tritanopia,
+        ColorVisionType.achromatopsia,
+        ColorVisionType.deuteranomaly,
+        ColorVisionType.tritanomaly,
+      ]) {
+        final out = await BeforeAfterView.renderAfter(src, type, 1.0);
+        expect(out, isNull, reason: '$type');
+      }
+    });
+  });
+
+  group('BeforeAfterView ウィジェット', () {
+    testWidgets('protanopia で原画ラベルとフィルタ名ラベルの両ペインを出す',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: BeforeAfterView(
+              filterType: ColorVisionType.protanopia,
+              intensity: 1.0,
+              sampleSize: 32,
+            ),
+          ),
+        ),
+      );
+      // 画像生成 + GPU 描画の Future を解決させる。
+      await tester.pumpAndSettle();
+
+      expect(find.text('Original'), findsOneWidget);
+      expect(find.text(ColorVisionType.protanopia.displayName), findsOneWidget);
+    });
+
+    testWidgets('未実装フィルタでは coming soon プレースホルダを出す',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: BeforeAfterView(
+              filterType: ColorVisionType.deuteranopia,
+              intensity: 1.0,
+              sampleSize: 32,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rendering coming soon'), findsOneWidget);
+    });
+  });
+}

--- a/test/before_after_view_test.dart
+++ b/test/before_after_view_test.dart
@@ -105,6 +105,20 @@ void main() {
   });
 
   group('BeforeAfterView ウィジェット', () {
+    // 画像生成 / GPU 描画は実 microtask 上で走るため runAsync 内でポンプし、
+    // 目的テキストが現れるまで待つヘルパ。pumpAndSettle はロード/描画の
+    // 非同期完了を待てない（かつアニメーションで収束しない）ため使わない。
+    Future<void> pumpUntilText(WidgetTester tester, String text) async {
+      await tester.runAsync(() async {
+        for (var i = 0; i < 50; i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          if (find.text(text).evaluate().isNotEmpty) return;
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      });
+      await tester.pump();
+    }
+
     testWidgets('protanopia で原画ラベルとフィルタ名ラベルの両ペインを出す',
         (tester) async {
       await tester.pumpWidget(
@@ -118,8 +132,7 @@ void main() {
           ),
         ),
       );
-      // 画像生成 + GPU 描画の Future を解決させる。
-      await tester.pumpAndSettle();
+      await pumpUntilText(tester, ColorVisionType.protanopia.displayName);
 
       expect(find.text('Original'), findsOneWidget);
       expect(find.text(ColorVisionType.protanopia.displayName), findsOneWidget);
@@ -138,7 +151,7 @@ void main() {
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      await pumpUntilText(tester, 'Rendering coming soon');
 
       expect(find.text('Rendering coming soon'), findsOneWidget);
     });

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:universal_experience/models/disability_type.dart';
+import 'package:universal_experience/services/settings_service.dart';
+
+/// SettingsService の永続化（shared_preferences）テスト。
+///
+/// SharedPreferences.setMockInitialValues でディスクをモックし、保存（set*）と
+/// 復元（load）の往復が正しいことを検証する（#17）。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsService 初期状態 / load', () {
+    test('保存値が無いときは既定（system / none / 1.0）を保つ', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsService();
+      await settings.load();
+
+      expect(settings.themeMode, ThemeMode.system);
+      expect(settings.filterType, ColorVisionType.none);
+      expect(settings.intensity, 1.0);
+    });
+
+    test('保存済みの値を復元する', () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsService.keyThemeMode: ThemeMode.dark.name,
+        SettingsService.keyFilterType: ColorVisionType.protanopia.name,
+        SettingsService.keyIntensity: 0.4,
+      });
+      final settings = SettingsService();
+      await settings.load();
+
+      expect(settings.themeMode, ThemeMode.dark);
+      expect(settings.filterType, ColorVisionType.protanopia);
+      expect(settings.intensity, 0.4);
+    });
+
+    test('未知の文字列は既定にフォールバックする', () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsService.keyThemeMode: 'bogus',
+        SettingsService.keyFilterType: 'not_a_filter',
+      });
+      final settings = SettingsService();
+      await settings.load();
+
+      expect(settings.themeMode, ThemeMode.system);
+      expect(settings.filterType, ColorVisionType.none);
+    });
+
+    test('範囲外の intensity は 0..1 に clamp して復元する', () async {
+      SharedPreferences.setMockInitialValues({
+        SettingsService.keyIntensity: 5.0,
+      });
+      final settings = SettingsService();
+      await settings.load();
+      expect(settings.intensity, 1.0);
+    });
+  });
+
+  group('SettingsService 保存 + 永続化往復', () {
+    test('setThemeMode は notify し別インスタンスの load で復元される', () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = SettingsService();
+      await a.load();
+      var notified = 0;
+      a.addListener(() => notified++);
+
+      await a.setThemeMode(ThemeMode.light);
+      expect(a.themeMode, ThemeMode.light);
+      expect(notified, 1);
+
+      // 同じモック store を読む新インスタンスで永続化を確認。
+      final b = SettingsService();
+      await b.load();
+      expect(b.themeMode, ThemeMode.light);
+    });
+
+    test('setFilterType / setIntensity が往復する', () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = SettingsService();
+      await a.load();
+
+      await a.setFilterType(ColorVisionType.deuteranomaly);
+      await a.setIntensity(0.25);
+
+      final b = SettingsService();
+      await b.load();
+      expect(b.filterType, ColorVisionType.deuteranomaly);
+      expect(b.intensity, 0.25);
+    });
+
+    test('同じ値の再設定では notify しない', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsService();
+      await settings.load();
+      var notified = 0;
+      settings.addListener(() => notified++);
+
+      await settings.setThemeMode(ThemeMode.system); // 既定と同じ
+      await settings.setIntensity(1.0); // 既定と同じ
+      await settings.setFilterType(ColorVisionType.none); // 既定と同じ
+      expect(notified, 0);
+    });
+
+    test('setIntensity は clamp してから保存する', () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = SettingsService();
+      await a.load();
+      await a.setIntensity(-3.0);
+      expect(a.intensity, 0.0);
+
+      final b = SettingsService();
+      await b.load();
+      expect(b.intensity, 0.0);
+    });
+
+    test('全 ThemeMode が name 経由で往復する', () async {
+      for (final mode in ThemeMode.values) {
+        SharedPreferences.setMockInitialValues({});
+        final a = SettingsService();
+        await a.load();
+        await a.setThemeMode(mode);
+        final b = SettingsService();
+        await b.load();
+        expect(b.themeMode, mode, reason: '$mode');
+      }
+    });
+
+    test('全 ColorVisionType が name 経由で往復する', () async {
+      for (final type in ColorVisionType.values) {
+        SharedPreferences.setMockInitialValues({});
+        final a = SettingsService();
+        await a.load();
+        await a.setFilterType(type);
+        final b = SettingsService();
+        await b.load();
+        expect(b.filterType, type, reason: '$type');
+      }
+    });
+  });
+}


### PR DESCRIPTION
closes #17

## 変更
- app_theme.dart を Material3(ColorScheme.fromSeed, teal seed)に刷新
- before_after_view.dart: サンプル画像に原画/フィルタ後を並置。protanopia/protanomaly は ShaderFilter で実描画、他5種はプレースホルダ
- settings_service.dart: themeMode/filterType/intensity を shared_preferences で永続化・復元
- home_screen に before/after カード + テーマ切替ボタン

## 検証
flutter analyze: No issues / flutter test: 全緑(+19) / build linux: 成功。GUI 実機目視は Wayland 制約で未実施。

## 非スコープ
i18n実翻訳(#18)、プリセット(#19)、トレイ(#15)