### PR TITLE
test: widget_test の placeholder を本体ウィジェットのスモークに書き換え (#30)

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,40 @@
+// アプリ本体ウィジェット（UniversalExperienceApp）の軽量スモークテスト。
+//
+// 旧 placeholder は Flutter の counter テンプレートのまま残っており、存在しない
+// `MyApp` を参照して `flutter analyze` をエラーにしていた（#30）。
+//
+// 本アプリの `main()` は async で `windowManager.ensureInitialized()` /
+// `TrayService.init()` 等のデスクトップ初期化を行うため、`main()` 自体を
+// testWidgets で踏むのは重く headless では不安定。一方、画面を構築する本体
+// ウィジェット `UniversalExperienceApp` はデスクトップ初期化に依存せず、
+// `SettingsService` だけを引数に取る（windowManager/トレイ配線は main() 側に
+// 閉じている）。よってここでは本体ウィジェットだけを pump してスモークする。
+//
+// SharedPreferences はモックし、ディスク I/O やプラットフォームチャネルを踏まない。
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:universal_experience/main.dart';
+import 'package:universal_experience/services/settings_service.dart';
+import 'package:universal_experience/ui/screens/home_screen.dart';
+
+void main() {
+  testWidgets('UniversalExperienceApp が例外なく起動し HomeScreen を表示する',
+      (WidgetTester tester) async {
+    // 永続化レイヤをモックして実ディスクを触らない（main() の settings.load()
+    // 相当を、デスクトップ初期化なしで再現する）。
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final settings = SettingsService();
+    await settings.load();
+
+    // main() は windowManager/トレイ初期化のあとに runApp(UniversalExperienceApp)
+    // を呼ぶ。本テストはその UI 部分（本体ウィジェット）だけを構築する。
+    await tester.pumpWidget(UniversalExperienceApp(settings: settings));
+
+    // アニメーション完走を待つと無限再描画で固まりうるため pumpAndSettle は使わず、
+    // 初回フレームが描けたこと（= 起動が例外なく成立したこと）だけを確認する。
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(find.byType(HomeScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 概要
Closes #30。

`test/widget_test.dart` は Flutter の counter テンプレート placeholder のまま残っており、存在しない `MyApp` を参照して `flutter analyze` をエラー1件・`flutter test` を1件失敗させていた（死んだテスト）。

## 変更
- placeholder を削除し、本体ウィジェット `UniversalExperienceApp` の軽量スモークテストに書き換えた。
- `main()` は `windowManager.ensureInitialized()` / `TrayService.init()` 等のデスクトップ初期化を伴い headless では重く不安定なため、`main()` ではなく UI 部分の本体ウィジェットだけを `pumpWidget` する。
- `SharedPreferences.setMockInitialValues({})` で永続化をモックし実ディスク/プラットフォームチャネルを踏まない。
- アニメーション完走待ち（`pumpAndSettle`）は無限再描画で固まりうるため使わず、初回フレームで `MaterialApp` と `HomeScreen` が立つこと（= 起動が例外なく成立したこと）だけを検証。

## 実コマンド検証
- `flutter analyze` → **No issues found!**（修正前: `MyApp` 参照で1件エラー）
- `flutter test` → **164/164 passed**（修正前: 163 passed +1 failed）
- `flutter test test/widget_test.dart` → 単体でも pass

完了条件（issue 記載: `flutter analyze` が緑）を満たす。analyze/test で完結する issue のため close 予定。

## スコープ外
- pubspec.lock の既存 dirty 差分（meta/test_api の版差）は本 PR と無関係なため取り込まない。