### PR TITLE
ci: push/PR で flutter analyze/test + cargo fmt/clippy/test を回す CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # Flutter golden テストはゴールデン生成時のプラットフォーム (macOS) と揃える必要が
+    # あるため macos-latest。sibling の selona と統一。
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Flutter analyze
+        run: flutter analyze
+
+      - name: Flutter test
+        run: flutter test
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      # rust 依存は crates.io のみ (sensus-core)。private git 依存が無いので
+      # selona のような deploy key / ssh-agent 手順は不要。
+      - name: Rust fmt check
+        working-directory: rust
+        run: cargo fmt --check
+
+      - name: Rust clippy
+        working-directory: rust
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Rust test
+        working-directory: rust
+        run: cargo test


### PR DESCRIPTION
Closes #38

## 穴
UE は `.github/workflows/` が無く **CI ゼロ**。flutter test 167 / cargo 22 / flutter analyze がすべて手動。sibling の selona（同じ Flutter+flutter_rust_bridge）は CI を持つのに UE だけ空白だった。

## 対応
selona の ci.yml を手本に UE 版を追加。UE 固有の差分:
- **deploy key 不要**: rust 依存は crates.io のみ（`sensus-core 0.5`・private git 依存なし）→ selona の pink-072 SSH clone 用 ssh-agent 手順を省略
- **`cargo test` を追加**: rust 側に 22 テスト（golden_gen + sensus_bridge）があるため
- `runs-on: macos-latest`（selona と統一・Flutter golden を生成プラットフォームと揃える）

ステップ: flutter pub get → analyze → test → (rust) fmt --check → clippy --all-targets -D warnings → cargo test。`concurrency` で古い実行をキャンセル。

## ローカル検証（Rust 側）
- `cargo fmt --check` 緑
- `cargo clippy --all-targets -- -D warnings` クリーン
- `cargo test` 21 passed + 1 ignored
- flutter 側はこの開発機に flutter 未導入のため未実行。session698 で mac 上の flutter test 167 / analyze 緑を確認済み。

## 注意
GitHub 上の CI 実行は現在アカウント全体の Actions ランナー枯渇（課金）で回らない。**設定を揃えて待機**させ、billing 復旧後に発火する想定（"先に用意"）。