### PR TITLE
feat: sensus の Experience/Urgency/HearingFilter を FRB 公開（Refs #10） (#10 部分)

### DIFF
--- a/lib/src/rust/api/sensus_bridge.dart
+++ b/lib/src/rust/api/sensus_bridge.dart
@@ -8,8 +8,8 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'sensus_bridge.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `color_matrix_flat`, `to_sensus`, `to_sensus`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `color_matrix_flat`, `from_sensus`, `from_sensus`, `from_sensus`, `from_sensus`, `from_sensus`, `to_sensus`, `to_sensus`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 /// 指定フィルタの GLSL ES 3.00 ソースを返す。
 ///
@@ -82,6 +82,134 @@ Uint8List applyVisionCpuRgba8(
         width: width,
         height: height,
         strength: strength);
+
+/// sensus-core が正準化した複合体験のプリセット 4 種を Dart へ返す。
+///
+/// 順序固定: meniere / bppv / vestibular_neuritis / labyrinthitis。各体験の視覚・聴覚
+/// フィルタと緊急度は sensus の `Experience::MENIERE` 等の const をミラーへ変換したもの。
+/// 文言は含まない（`id`・分類のみ）。体験名・緊急度メッセージ・聴覚症状の説明は
+/// Dart 側 i18n（#18）が解決する。
+List<Experience> experiences() =>
+    RustLib.instance.api.crateApiSensusBridgeExperiences();
+
+/// 視覚 + 聴覚にまたがる「複合体験」の Dart 公開ミラー。`sensus_core::Experience` 由来。
+///
+/// sensus は pure・別バッファ（画像 / 音声）のため、メニエール病のような「回転性めまい
+/// （視覚）＋ 難聴・耳鳴り（聴覚）」の複合症状を 1 バッファで表せない。`Experience` は
+/// 「どの視覚フィルタとどの聴覚フィルタを組にすれば仕様どおりの複合体験になるか」の
+/// 正準化を sensus から受け取る。Dart 側は三徴候の組み合わせをハードコードせず、
+/// [`experiences`] から取得する。
+///
+/// `id` は安定した英語識別子（i18n キー）。文言（体験名・説明）は持たず、Dart 側 i18n が
+/// `id` をキーに解決する。
+class Experience {
+  /// 安定した識別子（i18n キー等に使う英語 ID）。sensus は `&'static str` だが
+  /// FRB は `String` で出す。
+  final String id;
+
+  /// 視覚側フィルタ（視覚要素が無い体験では `None`）。
+  final VisionFilter? vision;
+
+  /// 聴覚側フィルタ（聴覚要素が無い体験では `None`）。
+  final HearingFilter? hearing;
+
+  /// 受診喚起の緊急度。
+  final Urgency urgency;
+
+  const Experience({
+    required this.id,
+    this.vision,
+    this.hearing,
+    required this.urgency,
+  });
+
+  @override
+  int get hashCode =>
+      id.hashCode ^ vision.hashCode ^ hearing.hashCode ^ urgency.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Experience &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          vision == other.vision &&
+          hearing == other.hearing &&
+          urgency == other.urgency;
+}
+
+@freezed
+sealed class HearingFilter with _$HearingFilter {
+  const HearingFilter._();
+
+  /// 難聴: 高音域カット。
+  const factory HearingFilter.hearingLoss() = HearingFilter_HearingLoss;
+
+  /// 突発性難聴: 特定周波数帯の急激な損失。
+  const factory HearingFilter.suddenHearingLoss({
+    required double freqHz,
+  }) = HearingFilter_SuddenHearingLoss;
+
+  /// 騒音性難聴: 4 kHz 付近の損失。
+  const factory HearingFilter.noiseInducedHearingLoss() =
+      HearingFilter_NoiseInducedHearingLoss;
+
+  /// 耳鳴り: 指定周波数の正弦波を常時ミックス。
+  const factory HearingFilter.tinnitus({
+    required double freqHz,
+  }) = HearingFilter_Tinnitus;
+
+  /// 音響過敏: 音量を異常に増幅。
+  const factory HearingFilter.hyperacusis() = HearingFilter_Hyperacusis;
+
+  /// ミソフォニア: `freq_hz` 中心のトリガー帯域を過剰増幅 + 歪み。
+  const factory HearingFilter.misophonia({
+    required double freqHz,
+  }) = HearingFilter_Misophonia;
+
+  /// 変音: 音を歪んだ・金属的な質感に加工。
+  const factory HearingFilter.paracusis() = HearingFilter_Paracusis;
+
+  /// 音楽音痴: 音程の違いを識別しにくくする。
+  const factory HearingFilter.amusia() = HearingFilter_Amusia;
+
+  /// ジスメロディア: 音楽を不快・歪んだ音に変換。
+  const factory HearingFilter.dysmelodia() = HearingFilter_Dysmelodia;
+
+  /// 音程シフト: 半音単位で全体音程をシフト。
+  const factory HearingFilter.pitchShift({
+    required double semitones,
+  }) = HearingFilter_PitchShift;
+
+  /// ダイプラクシス: 左右耳で異なる音程を知覚。
+  const factory HearingFilter.diplacusis() = HearingFilter_Diplacusis;
+
+  /// APD（聴覚情報処理障害）: 時間分解能低下 + 雑音付加。
+  const factory HearingFilter.auditoryProcessingDisorder() =
+      HearingFilter_AuditoryProcessingDisorder;
+
+  /// メニエール病の聴覚側: 低音域難聴 + 低い唸る耳鳴り。
+  const factory HearingFilter.meniere() = HearingFilter_Meniere;
+
+  /// 迷路炎の聴覚側: 高音域感音難聴 + 高音の耳鳴り。
+  const factory HearingFilter.labyrinthitis() = HearingFilter_Labyrinthitis;
+}
+
+/// 受診喚起の緊急度分類。`sensus_core::Urgency` の FRB 公開ミラー。
+///
+/// 文言は持たない（分類のみ）。⚠️/🚨 等の表示文言は Dart 側 i18n が
+/// このバリアントをキーに出し分ける。
+enum Urgency {
+  /// 緊急性の注記なし。
+  none,
+
+  /// 早期受診が望ましい。
+  earlyConsultation,
+
+  /// 即救急（脳卒中等のサインの可能性）。
+  emergency,
+  ;
+}
 
 @freezed
 sealed class VisionFilter with _$VisionFilter {

--- a/lib/src/rust/api/sensus_bridge.freezed.dart
+++ b/lib/src/rust/api/sensus_bridge.freezed.dart
@@ -15,6 +15,2934 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
+mixin _$HearingFilter {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HearingFilterCopyWith<$Res> {
+  factory $HearingFilterCopyWith(
+          HearingFilter value, $Res Function(HearingFilter) then) =
+      _$HearingFilterCopyWithImpl<$Res, HearingFilter>;
+}
+
+/// @nodoc
+class _$HearingFilterCopyWithImpl<$Res, $Val extends HearingFilter>
+    implements $HearingFilterCopyWith<$Res> {
+  _$HearingFilterCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_HearingLossImplCopyWith<$Res> {
+  factory _$$HearingFilter_HearingLossImplCopyWith(
+          _$HearingFilter_HearingLossImpl value,
+          $Res Function(_$HearingFilter_HearingLossImpl) then) =
+      __$$HearingFilter_HearingLossImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_HearingLossImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_HearingLossImpl>
+    implements _$$HearingFilter_HearingLossImplCopyWith<$Res> {
+  __$$HearingFilter_HearingLossImplCopyWithImpl(
+      _$HearingFilter_HearingLossImpl _value,
+      $Res Function(_$HearingFilter_HearingLossImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_HearingLossImpl extends HearingFilter_HearingLoss {
+  const _$HearingFilter_HearingLossImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.hearingLoss()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_HearingLossImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return hearingLoss();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return hearingLoss?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (hearingLoss != null) {
+      return hearingLoss();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return hearingLoss(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return hearingLoss?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (hearingLoss != null) {
+      return hearingLoss(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_HearingLoss extends HearingFilter {
+  const factory HearingFilter_HearingLoss() = _$HearingFilter_HearingLossImpl;
+  const HearingFilter_HearingLoss._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_SuddenHearingLossImplCopyWith<$Res> {
+  factory _$$HearingFilter_SuddenHearingLossImplCopyWith(
+          _$HearingFilter_SuddenHearingLossImpl value,
+          $Res Function(_$HearingFilter_SuddenHearingLossImpl) then) =
+      __$$HearingFilter_SuddenHearingLossImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double freqHz});
+}
+
+/// @nodoc
+class __$$HearingFilter_SuddenHearingLossImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res,
+        _$HearingFilter_SuddenHearingLossImpl>
+    implements _$$HearingFilter_SuddenHearingLossImplCopyWith<$Res> {
+  __$$HearingFilter_SuddenHearingLossImplCopyWithImpl(
+      _$HearingFilter_SuddenHearingLossImpl _value,
+      $Res Function(_$HearingFilter_SuddenHearingLossImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? freqHz = null,
+  }) {
+    return _then(_$HearingFilter_SuddenHearingLossImpl(
+      freqHz: null == freqHz
+          ? _value.freqHz
+          : freqHz // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HearingFilter_SuddenHearingLossImpl
+    extends HearingFilter_SuddenHearingLoss {
+  const _$HearingFilter_SuddenHearingLossImpl({required this.freqHz})
+      : super._();
+
+  @override
+  final double freqHz;
+
+  @override
+  String toString() {
+    return 'HearingFilter.suddenHearingLoss(freqHz: $freqHz)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_SuddenHearingLossImpl &&
+            (identical(other.freqHz, freqHz) || other.freqHz == freqHz));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, freqHz);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HearingFilter_SuddenHearingLossImplCopyWith<
+          _$HearingFilter_SuddenHearingLossImpl>
+      get copyWith => __$$HearingFilter_SuddenHearingLossImplCopyWithImpl<
+          _$HearingFilter_SuddenHearingLossImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return suddenHearingLoss(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return suddenHearingLoss?.call(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (suddenHearingLoss != null) {
+      return suddenHearingLoss(freqHz);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return suddenHearingLoss(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return suddenHearingLoss?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (suddenHearingLoss != null) {
+      return suddenHearingLoss(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_SuddenHearingLoss extends HearingFilter {
+  const factory HearingFilter_SuddenHearingLoss(
+      {required final double freqHz}) = _$HearingFilter_SuddenHearingLossImpl;
+  const HearingFilter_SuddenHearingLoss._() : super._();
+
+  double get freqHz;
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HearingFilter_SuddenHearingLossImplCopyWith<
+          _$HearingFilter_SuddenHearingLossImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_NoiseInducedHearingLossImplCopyWith<$Res> {
+  factory _$$HearingFilter_NoiseInducedHearingLossImplCopyWith(
+          _$HearingFilter_NoiseInducedHearingLossImpl value,
+          $Res Function(_$HearingFilter_NoiseInducedHearingLossImpl) then) =
+      __$$HearingFilter_NoiseInducedHearingLossImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_NoiseInducedHearingLossImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res,
+        _$HearingFilter_NoiseInducedHearingLossImpl>
+    implements _$$HearingFilter_NoiseInducedHearingLossImplCopyWith<$Res> {
+  __$$HearingFilter_NoiseInducedHearingLossImplCopyWithImpl(
+      _$HearingFilter_NoiseInducedHearingLossImpl _value,
+      $Res Function(_$HearingFilter_NoiseInducedHearingLossImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_NoiseInducedHearingLossImpl
+    extends HearingFilter_NoiseInducedHearingLoss {
+  const _$HearingFilter_NoiseInducedHearingLossImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.noiseInducedHearingLoss()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_NoiseInducedHearingLossImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return noiseInducedHearingLoss();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return noiseInducedHearingLoss?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (noiseInducedHearingLoss != null) {
+      return noiseInducedHearingLoss();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return noiseInducedHearingLoss(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return noiseInducedHearingLoss?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (noiseInducedHearingLoss != null) {
+      return noiseInducedHearingLoss(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_NoiseInducedHearingLoss extends HearingFilter {
+  const factory HearingFilter_NoiseInducedHearingLoss() =
+      _$HearingFilter_NoiseInducedHearingLossImpl;
+  const HearingFilter_NoiseInducedHearingLoss._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_TinnitusImplCopyWith<$Res> {
+  factory _$$HearingFilter_TinnitusImplCopyWith(
+          _$HearingFilter_TinnitusImpl value,
+          $Res Function(_$HearingFilter_TinnitusImpl) then) =
+      __$$HearingFilter_TinnitusImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double freqHz});
+}
+
+/// @nodoc
+class __$$HearingFilter_TinnitusImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_TinnitusImpl>
+    implements _$$HearingFilter_TinnitusImplCopyWith<$Res> {
+  __$$HearingFilter_TinnitusImplCopyWithImpl(
+      _$HearingFilter_TinnitusImpl _value,
+      $Res Function(_$HearingFilter_TinnitusImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? freqHz = null,
+  }) {
+    return _then(_$HearingFilter_TinnitusImpl(
+      freqHz: null == freqHz
+          ? _value.freqHz
+          : freqHz // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HearingFilter_TinnitusImpl extends HearingFilter_Tinnitus {
+  const _$HearingFilter_TinnitusImpl({required this.freqHz}) : super._();
+
+  @override
+  final double freqHz;
+
+  @override
+  String toString() {
+    return 'HearingFilter.tinnitus(freqHz: $freqHz)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_TinnitusImpl &&
+            (identical(other.freqHz, freqHz) || other.freqHz == freqHz));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, freqHz);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HearingFilter_TinnitusImplCopyWith<_$HearingFilter_TinnitusImpl>
+      get copyWith => __$$HearingFilter_TinnitusImplCopyWithImpl<
+          _$HearingFilter_TinnitusImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return tinnitus(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return tinnitus?.call(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (tinnitus != null) {
+      return tinnitus(freqHz);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return tinnitus(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return tinnitus?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (tinnitus != null) {
+      return tinnitus(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Tinnitus extends HearingFilter {
+  const factory HearingFilter_Tinnitus({required final double freqHz}) =
+      _$HearingFilter_TinnitusImpl;
+  const HearingFilter_Tinnitus._() : super._();
+
+  double get freqHz;
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HearingFilter_TinnitusImplCopyWith<_$HearingFilter_TinnitusImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_HyperacusisImplCopyWith<$Res> {
+  factory _$$HearingFilter_HyperacusisImplCopyWith(
+          _$HearingFilter_HyperacusisImpl value,
+          $Res Function(_$HearingFilter_HyperacusisImpl) then) =
+      __$$HearingFilter_HyperacusisImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_HyperacusisImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_HyperacusisImpl>
+    implements _$$HearingFilter_HyperacusisImplCopyWith<$Res> {
+  __$$HearingFilter_HyperacusisImplCopyWithImpl(
+      _$HearingFilter_HyperacusisImpl _value,
+      $Res Function(_$HearingFilter_HyperacusisImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_HyperacusisImpl extends HearingFilter_Hyperacusis {
+  const _$HearingFilter_HyperacusisImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.hyperacusis()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_HyperacusisImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return hyperacusis();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return hyperacusis?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (hyperacusis != null) {
+      return hyperacusis();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return hyperacusis(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return hyperacusis?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (hyperacusis != null) {
+      return hyperacusis(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Hyperacusis extends HearingFilter {
+  const factory HearingFilter_Hyperacusis() = _$HearingFilter_HyperacusisImpl;
+  const HearingFilter_Hyperacusis._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_MisophoniaImplCopyWith<$Res> {
+  factory _$$HearingFilter_MisophoniaImplCopyWith(
+          _$HearingFilter_MisophoniaImpl value,
+          $Res Function(_$HearingFilter_MisophoniaImpl) then) =
+      __$$HearingFilter_MisophoniaImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double freqHz});
+}
+
+/// @nodoc
+class __$$HearingFilter_MisophoniaImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_MisophoniaImpl>
+    implements _$$HearingFilter_MisophoniaImplCopyWith<$Res> {
+  __$$HearingFilter_MisophoniaImplCopyWithImpl(
+      _$HearingFilter_MisophoniaImpl _value,
+      $Res Function(_$HearingFilter_MisophoniaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? freqHz = null,
+  }) {
+    return _then(_$HearingFilter_MisophoniaImpl(
+      freqHz: null == freqHz
+          ? _value.freqHz
+          : freqHz // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HearingFilter_MisophoniaImpl extends HearingFilter_Misophonia {
+  const _$HearingFilter_MisophoniaImpl({required this.freqHz}) : super._();
+
+  @override
+  final double freqHz;
+
+  @override
+  String toString() {
+    return 'HearingFilter.misophonia(freqHz: $freqHz)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_MisophoniaImpl &&
+            (identical(other.freqHz, freqHz) || other.freqHz == freqHz));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, freqHz);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HearingFilter_MisophoniaImplCopyWith<_$HearingFilter_MisophoniaImpl>
+      get copyWith => __$$HearingFilter_MisophoniaImplCopyWithImpl<
+          _$HearingFilter_MisophoniaImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return misophonia(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return misophonia?.call(freqHz);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (misophonia != null) {
+      return misophonia(freqHz);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return misophonia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return misophonia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (misophonia != null) {
+      return misophonia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Misophonia extends HearingFilter {
+  const factory HearingFilter_Misophonia({required final double freqHz}) =
+      _$HearingFilter_MisophoniaImpl;
+  const HearingFilter_Misophonia._() : super._();
+
+  double get freqHz;
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HearingFilter_MisophoniaImplCopyWith<_$HearingFilter_MisophoniaImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_ParacusisImplCopyWith<$Res> {
+  factory _$$HearingFilter_ParacusisImplCopyWith(
+          _$HearingFilter_ParacusisImpl value,
+          $Res Function(_$HearingFilter_ParacusisImpl) then) =
+      __$$HearingFilter_ParacusisImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_ParacusisImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_ParacusisImpl>
+    implements _$$HearingFilter_ParacusisImplCopyWith<$Res> {
+  __$$HearingFilter_ParacusisImplCopyWithImpl(
+      _$HearingFilter_ParacusisImpl _value,
+      $Res Function(_$HearingFilter_ParacusisImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_ParacusisImpl extends HearingFilter_Paracusis {
+  const _$HearingFilter_ParacusisImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.paracusis()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_ParacusisImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return paracusis();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return paracusis?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (paracusis != null) {
+      return paracusis();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return paracusis(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return paracusis?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (paracusis != null) {
+      return paracusis(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Paracusis extends HearingFilter {
+  const factory HearingFilter_Paracusis() = _$HearingFilter_ParacusisImpl;
+  const HearingFilter_Paracusis._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_AmusiaImplCopyWith<$Res> {
+  factory _$$HearingFilter_AmusiaImplCopyWith(_$HearingFilter_AmusiaImpl value,
+          $Res Function(_$HearingFilter_AmusiaImpl) then) =
+      __$$HearingFilter_AmusiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_AmusiaImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_AmusiaImpl>
+    implements _$$HearingFilter_AmusiaImplCopyWith<$Res> {
+  __$$HearingFilter_AmusiaImplCopyWithImpl(_$HearingFilter_AmusiaImpl _value,
+      $Res Function(_$HearingFilter_AmusiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_AmusiaImpl extends HearingFilter_Amusia {
+  const _$HearingFilter_AmusiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.amusia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_AmusiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return amusia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return amusia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (amusia != null) {
+      return amusia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return amusia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return amusia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (amusia != null) {
+      return amusia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Amusia extends HearingFilter {
+  const factory HearingFilter_Amusia() = _$HearingFilter_AmusiaImpl;
+  const HearingFilter_Amusia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_DysmelodiaImplCopyWith<$Res> {
+  factory _$$HearingFilter_DysmelodiaImplCopyWith(
+          _$HearingFilter_DysmelodiaImpl value,
+          $Res Function(_$HearingFilter_DysmelodiaImpl) then) =
+      __$$HearingFilter_DysmelodiaImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_DysmelodiaImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_DysmelodiaImpl>
+    implements _$$HearingFilter_DysmelodiaImplCopyWith<$Res> {
+  __$$HearingFilter_DysmelodiaImplCopyWithImpl(
+      _$HearingFilter_DysmelodiaImpl _value,
+      $Res Function(_$HearingFilter_DysmelodiaImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_DysmelodiaImpl extends HearingFilter_Dysmelodia {
+  const _$HearingFilter_DysmelodiaImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.dysmelodia()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_DysmelodiaImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return dysmelodia();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return dysmelodia?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (dysmelodia != null) {
+      return dysmelodia();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return dysmelodia(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return dysmelodia?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (dysmelodia != null) {
+      return dysmelodia(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Dysmelodia extends HearingFilter {
+  const factory HearingFilter_Dysmelodia() = _$HearingFilter_DysmelodiaImpl;
+  const HearingFilter_Dysmelodia._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_PitchShiftImplCopyWith<$Res> {
+  factory _$$HearingFilter_PitchShiftImplCopyWith(
+          _$HearingFilter_PitchShiftImpl value,
+          $Res Function(_$HearingFilter_PitchShiftImpl) then) =
+      __$$HearingFilter_PitchShiftImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double semitones});
+}
+
+/// @nodoc
+class __$$HearingFilter_PitchShiftImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_PitchShiftImpl>
+    implements _$$HearingFilter_PitchShiftImplCopyWith<$Res> {
+  __$$HearingFilter_PitchShiftImplCopyWithImpl(
+      _$HearingFilter_PitchShiftImpl _value,
+      $Res Function(_$HearingFilter_PitchShiftImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? semitones = null,
+  }) {
+    return _then(_$HearingFilter_PitchShiftImpl(
+      semitones: null == semitones
+          ? _value.semitones
+          : semitones // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$HearingFilter_PitchShiftImpl extends HearingFilter_PitchShift {
+  const _$HearingFilter_PitchShiftImpl({required this.semitones}) : super._();
+
+  @override
+  final double semitones;
+
+  @override
+  String toString() {
+    return 'HearingFilter.pitchShift(semitones: $semitones)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_PitchShiftImpl &&
+            (identical(other.semitones, semitones) ||
+                other.semitones == semitones));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, semitones);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HearingFilter_PitchShiftImplCopyWith<_$HearingFilter_PitchShiftImpl>
+      get copyWith => __$$HearingFilter_PitchShiftImplCopyWithImpl<
+          _$HearingFilter_PitchShiftImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return pitchShift(semitones);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return pitchShift?.call(semitones);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (pitchShift != null) {
+      return pitchShift(semitones);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return pitchShift(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return pitchShift?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (pitchShift != null) {
+      return pitchShift(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_PitchShift extends HearingFilter {
+  const factory HearingFilter_PitchShift({required final double semitones}) =
+      _$HearingFilter_PitchShiftImpl;
+  const HearingFilter_PitchShift._() : super._();
+
+  double get semitones;
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$HearingFilter_PitchShiftImplCopyWith<_$HearingFilter_PitchShiftImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_DiplacusisImplCopyWith<$Res> {
+  factory _$$HearingFilter_DiplacusisImplCopyWith(
+          _$HearingFilter_DiplacusisImpl value,
+          $Res Function(_$HearingFilter_DiplacusisImpl) then) =
+      __$$HearingFilter_DiplacusisImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_DiplacusisImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_DiplacusisImpl>
+    implements _$$HearingFilter_DiplacusisImplCopyWith<$Res> {
+  __$$HearingFilter_DiplacusisImplCopyWithImpl(
+      _$HearingFilter_DiplacusisImpl _value,
+      $Res Function(_$HearingFilter_DiplacusisImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_DiplacusisImpl extends HearingFilter_Diplacusis {
+  const _$HearingFilter_DiplacusisImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.diplacusis()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_DiplacusisImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return diplacusis();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return diplacusis?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (diplacusis != null) {
+      return diplacusis();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return diplacusis(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return diplacusis?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (diplacusis != null) {
+      return diplacusis(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Diplacusis extends HearingFilter {
+  const factory HearingFilter_Diplacusis() = _$HearingFilter_DiplacusisImpl;
+  const HearingFilter_Diplacusis._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_AuditoryProcessingDisorderImplCopyWith<$Res> {
+  factory _$$HearingFilter_AuditoryProcessingDisorderImplCopyWith(
+          _$HearingFilter_AuditoryProcessingDisorderImpl value,
+          $Res Function(_$HearingFilter_AuditoryProcessingDisorderImpl) then) =
+      __$$HearingFilter_AuditoryProcessingDisorderImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_AuditoryProcessingDisorderImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res,
+        _$HearingFilter_AuditoryProcessingDisorderImpl>
+    implements _$$HearingFilter_AuditoryProcessingDisorderImplCopyWith<$Res> {
+  __$$HearingFilter_AuditoryProcessingDisorderImplCopyWithImpl(
+      _$HearingFilter_AuditoryProcessingDisorderImpl _value,
+      $Res Function(_$HearingFilter_AuditoryProcessingDisorderImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_AuditoryProcessingDisorderImpl
+    extends HearingFilter_AuditoryProcessingDisorder {
+  const _$HearingFilter_AuditoryProcessingDisorderImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.auditoryProcessingDisorder()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_AuditoryProcessingDisorderImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return auditoryProcessingDisorder();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return auditoryProcessingDisorder?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (auditoryProcessingDisorder != null) {
+      return auditoryProcessingDisorder();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return auditoryProcessingDisorder(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return auditoryProcessingDisorder?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (auditoryProcessingDisorder != null) {
+      return auditoryProcessingDisorder(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_AuditoryProcessingDisorder extends HearingFilter {
+  const factory HearingFilter_AuditoryProcessingDisorder() =
+      _$HearingFilter_AuditoryProcessingDisorderImpl;
+  const HearingFilter_AuditoryProcessingDisorder._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_MeniereImplCopyWith<$Res> {
+  factory _$$HearingFilter_MeniereImplCopyWith(
+          _$HearingFilter_MeniereImpl value,
+          $Res Function(_$HearingFilter_MeniereImpl) then) =
+      __$$HearingFilter_MeniereImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_MeniereImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_MeniereImpl>
+    implements _$$HearingFilter_MeniereImplCopyWith<$Res> {
+  __$$HearingFilter_MeniereImplCopyWithImpl(_$HearingFilter_MeniereImpl _value,
+      $Res Function(_$HearingFilter_MeniereImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_MeniereImpl extends HearingFilter_Meniere {
+  const _$HearingFilter_MeniereImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.meniere()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_MeniereImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return meniere();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return meniere?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (meniere != null) {
+      return meniere();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return meniere(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return meniere?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (meniere != null) {
+      return meniere(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Meniere extends HearingFilter {
+  const factory HearingFilter_Meniere() = _$HearingFilter_MeniereImpl;
+  const HearingFilter_Meniere._() : super._();
+}
+
+/// @nodoc
+abstract class _$$HearingFilter_LabyrinthitisImplCopyWith<$Res> {
+  factory _$$HearingFilter_LabyrinthitisImplCopyWith(
+          _$HearingFilter_LabyrinthitisImpl value,
+          $Res Function(_$HearingFilter_LabyrinthitisImpl) then) =
+      __$$HearingFilter_LabyrinthitisImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$HearingFilter_LabyrinthitisImplCopyWithImpl<$Res>
+    extends _$HearingFilterCopyWithImpl<$Res, _$HearingFilter_LabyrinthitisImpl>
+    implements _$$HearingFilter_LabyrinthitisImplCopyWith<$Res> {
+  __$$HearingFilter_LabyrinthitisImplCopyWithImpl(
+      _$HearingFilter_LabyrinthitisImpl _value,
+      $Res Function(_$HearingFilter_LabyrinthitisImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of HearingFilter
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$HearingFilter_LabyrinthitisImpl extends HearingFilter_Labyrinthitis {
+  const _$HearingFilter_LabyrinthitisImpl() : super._();
+
+  @override
+  String toString() {
+    return 'HearingFilter.labyrinthitis()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HearingFilter_LabyrinthitisImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() hearingLoss,
+    required TResult Function(double freqHz) suddenHearingLoss,
+    required TResult Function() noiseInducedHearingLoss,
+    required TResult Function(double freqHz) tinnitus,
+    required TResult Function() hyperacusis,
+    required TResult Function(double freqHz) misophonia,
+    required TResult Function() paracusis,
+    required TResult Function() amusia,
+    required TResult Function() dysmelodia,
+    required TResult Function(double semitones) pitchShift,
+    required TResult Function() diplacusis,
+    required TResult Function() auditoryProcessingDisorder,
+    required TResult Function() meniere,
+    required TResult Function() labyrinthitis,
+  }) {
+    return labyrinthitis();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? hearingLoss,
+    TResult? Function(double freqHz)? suddenHearingLoss,
+    TResult? Function()? noiseInducedHearingLoss,
+    TResult? Function(double freqHz)? tinnitus,
+    TResult? Function()? hyperacusis,
+    TResult? Function(double freqHz)? misophonia,
+    TResult? Function()? paracusis,
+    TResult? Function()? amusia,
+    TResult? Function()? dysmelodia,
+    TResult? Function(double semitones)? pitchShift,
+    TResult? Function()? diplacusis,
+    TResult? Function()? auditoryProcessingDisorder,
+    TResult? Function()? meniere,
+    TResult? Function()? labyrinthitis,
+  }) {
+    return labyrinthitis?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? hearingLoss,
+    TResult Function(double freqHz)? suddenHearingLoss,
+    TResult Function()? noiseInducedHearingLoss,
+    TResult Function(double freqHz)? tinnitus,
+    TResult Function()? hyperacusis,
+    TResult Function(double freqHz)? misophonia,
+    TResult Function()? paracusis,
+    TResult Function()? amusia,
+    TResult Function()? dysmelodia,
+    TResult Function(double semitones)? pitchShift,
+    TResult Function()? diplacusis,
+    TResult Function()? auditoryProcessingDisorder,
+    TResult Function()? meniere,
+    TResult Function()? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (labyrinthitis != null) {
+      return labyrinthitis();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(HearingFilter_HearingLoss value) hearingLoss,
+    required TResult Function(HearingFilter_SuddenHearingLoss value)
+        suddenHearingLoss,
+    required TResult Function(HearingFilter_NoiseInducedHearingLoss value)
+        noiseInducedHearingLoss,
+    required TResult Function(HearingFilter_Tinnitus value) tinnitus,
+    required TResult Function(HearingFilter_Hyperacusis value) hyperacusis,
+    required TResult Function(HearingFilter_Misophonia value) misophonia,
+    required TResult Function(HearingFilter_Paracusis value) paracusis,
+    required TResult Function(HearingFilter_Amusia value) amusia,
+    required TResult Function(HearingFilter_Dysmelodia value) dysmelodia,
+    required TResult Function(HearingFilter_PitchShift value) pitchShift,
+    required TResult Function(HearingFilter_Diplacusis value) diplacusis,
+    required TResult Function(HearingFilter_AuditoryProcessingDisorder value)
+        auditoryProcessingDisorder,
+    required TResult Function(HearingFilter_Meniere value) meniere,
+    required TResult Function(HearingFilter_Labyrinthitis value) labyrinthitis,
+  }) {
+    return labyrinthitis(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult? Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult? Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult? Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult? Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult? Function(HearingFilter_Misophonia value)? misophonia,
+    TResult? Function(HearingFilter_Paracusis value)? paracusis,
+    TResult? Function(HearingFilter_Amusia value)? amusia,
+    TResult? Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult? Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult? Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult? Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult? Function(HearingFilter_Meniere value)? meniere,
+    TResult? Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+  }) {
+    return labyrinthitis?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(HearingFilter_HearingLoss value)? hearingLoss,
+    TResult Function(HearingFilter_SuddenHearingLoss value)? suddenHearingLoss,
+    TResult Function(HearingFilter_NoiseInducedHearingLoss value)?
+        noiseInducedHearingLoss,
+    TResult Function(HearingFilter_Tinnitus value)? tinnitus,
+    TResult Function(HearingFilter_Hyperacusis value)? hyperacusis,
+    TResult Function(HearingFilter_Misophonia value)? misophonia,
+    TResult Function(HearingFilter_Paracusis value)? paracusis,
+    TResult Function(HearingFilter_Amusia value)? amusia,
+    TResult Function(HearingFilter_Dysmelodia value)? dysmelodia,
+    TResult Function(HearingFilter_PitchShift value)? pitchShift,
+    TResult Function(HearingFilter_Diplacusis value)? diplacusis,
+    TResult Function(HearingFilter_AuditoryProcessingDisorder value)?
+        auditoryProcessingDisorder,
+    TResult Function(HearingFilter_Meniere value)? meniere,
+    TResult Function(HearingFilter_Labyrinthitis value)? labyrinthitis,
+    required TResult orElse(),
+  }) {
+    if (labyrinthitis != null) {
+      return labyrinthitis(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class HearingFilter_Labyrinthitis extends HearingFilter {
+  const factory HearingFilter_Labyrinthitis() =
+      _$HearingFilter_LabyrinthitisImpl;
+  const HearingFilter_Labyrinthitis._() : super._();
+}
+
+/// @nodoc
 mixin _$VisionFilter {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -166308027;
+  int get rustContentHash => -326563465;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -85,6 +85,8 @@ abstract class RustLibApi extends BaseApi {
       required int width,
       required int height,
       required double strength});
+
+  List<Experience> crateApiSensusBridgeExperiences();
 
   String crateApiSensusBridgeVisionShaderGlsl({required VisionFilter filter});
 
@@ -138,6 +140,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: 'apply_vision_cpu_rgba8',
         argNames: ['filter', 'rgba8', 'width', 'height', 'strength'],
+      );
+
+  @override
+  List<Experience> crateApiSensusBridgeExperiences() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        return wire.wire__crate__api__sensus_bridge__experiences();
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_list_experience,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSensusBridgeExperiencesConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSensusBridgeExperiencesConstMeta =>
+      const TaskConstMeta(
+        debugName: 'experiences',
+        argNames: [],
       );
 
   @override
@@ -228,15 +252,80 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  HearingFilter dco_decode_box_autoadd_hearing_filter(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_hearing_filter(raw);
+  }
+
+  @protected
   VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_vision_filter(raw);
   }
 
   @protected
+  Experience dco_decode_experience(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return Experience(
+      id: dco_decode_String(arr[0]),
+      vision: dco_decode_opt_box_autoadd_vision_filter(arr[1]),
+      hearing: dco_decode_opt_box_autoadd_hearing_filter(arr[2]),
+      urgency: dco_decode_urgency(arr[3]),
+    );
+  }
+
+  @protected
   double dco_decode_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
+  }
+
+  @protected
+  HearingFilter dco_decode_hearing_filter(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return const HearingFilter_HearingLoss();
+      case 1:
+        return HearingFilter_SuddenHearingLoss(
+          freqHz: dco_decode_f_32(raw[1]),
+        );
+      case 2:
+        return const HearingFilter_NoiseInducedHearingLoss();
+      case 3:
+        return HearingFilter_Tinnitus(
+          freqHz: dco_decode_f_32(raw[1]),
+        );
+      case 4:
+        return const HearingFilter_Hyperacusis();
+      case 5:
+        return HearingFilter_Misophonia(
+          freqHz: dco_decode_f_32(raw[1]),
+        );
+      case 6:
+        return const HearingFilter_Paracusis();
+      case 7:
+        return const HearingFilter_Amusia();
+      case 8:
+        return const HearingFilter_Dysmelodia();
+      case 9:
+        return HearingFilter_PitchShift(
+          semitones: dco_decode_f_32(raw[1]),
+        );
+      case 10:
+        return const HearingFilter_Diplacusis();
+      case 11:
+        return const HearingFilter_AuditoryProcessingDisorder();
+      case 12:
+        return const HearingFilter_Meniere();
+      case 13:
+        return const HearingFilter_Labyrinthitis();
+      default:
+        throw Exception('unreachable');
+    }
   }
 
   @protected
@@ -249,6 +338,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  List<Experience> dco_decode_list_experience(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_experience).toList();
   }
 
   @protected
@@ -267,6 +362,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
+  }
+
+  @protected
+  HearingFilter? dco_decode_opt_box_autoadd_hearing_filter(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_hearing_filter(raw);
+  }
+
+  @protected
+  VisionFilter? dco_decode_opt_box_autoadd_vision_filter(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_vision_filter(raw);
   }
 
   @protected
@@ -291,6 +398,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void dco_decode_unit(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return;
+  }
+
+  @protected
+  Urgency dco_decode_urgency(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Urgency.values[raw as int];
   }
 
   @protected
@@ -409,6 +522,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  HearingFilter sse_decode_box_autoadd_hearing_filter(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_hearing_filter(deserializer));
+  }
+
+  @protected
   VisionFilter sse_decode_box_autoadd_vision_filter(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -416,9 +536,66 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Experience sse_decode_experience(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    var var_vision = sse_decode_opt_box_autoadd_vision_filter(deserializer);
+    var var_hearing = sse_decode_opt_box_autoadd_hearing_filter(deserializer);
+    var var_urgency = sse_decode_urgency(deserializer);
+    return Experience(
+        id: var_id,
+        vision: var_vision,
+        hearing: var_hearing,
+        urgency: var_urgency);
+  }
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat32();
+  }
+
+  @protected
+  HearingFilter sse_decode_hearing_filter(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return const HearingFilter_HearingLoss();
+      case 1:
+        var var_freqHz = sse_decode_f_32(deserializer);
+        return HearingFilter_SuddenHearingLoss(freqHz: var_freqHz);
+      case 2:
+        return const HearingFilter_NoiseInducedHearingLoss();
+      case 3:
+        var var_freqHz = sse_decode_f_32(deserializer);
+        return HearingFilter_Tinnitus(freqHz: var_freqHz);
+      case 4:
+        return const HearingFilter_Hyperacusis();
+      case 5:
+        var var_freqHz = sse_decode_f_32(deserializer);
+        return HearingFilter_Misophonia(freqHz: var_freqHz);
+      case 6:
+        return const HearingFilter_Paracusis();
+      case 7:
+        return const HearingFilter_Amusia();
+      case 8:
+        return const HearingFilter_Dysmelodia();
+      case 9:
+        var var_semitones = sse_decode_f_32(deserializer);
+        return HearingFilter_PitchShift(semitones: var_semitones);
+      case 10:
+        return const HearingFilter_Diplacusis();
+      case 11:
+        return const HearingFilter_AuditoryProcessingDisorder();
+      case 12:
+        return const HearingFilter_Meniere();
+      case 13:
+        return const HearingFilter_Labyrinthitis();
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -435,6 +612,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <String>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<Experience> sse_decode_list_experience(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <Experience>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_experience(deserializer));
     }
     return ans_;
   }
@@ -461,6 +650,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  HearingFilter? sse_decode_opt_box_autoadd_hearing_filter(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_hearing_filter(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  VisionFilter? sse_decode_opt_box_autoadd_vision_filter(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_vision_filter(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   int sse_decode_u_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint32();
@@ -481,6 +694,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_decode_unit(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  Urgency sse_decode_urgency(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return Urgency.values[inner];
   }
 
   @protected
@@ -634,6 +854,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  int cst_encode_urgency(Urgency raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_32(raw.index);
+  }
+
+  @protected
   int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_i_32(raw.index);
@@ -646,6 +872,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_hearing_filter(
+      HearingFilter self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_hearing_filter(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_vision_filter(
       VisionFilter self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -653,9 +886,57 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_experience(Experience self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+    sse_encode_opt_box_autoadd_vision_filter(self.vision, serializer);
+    sse_encode_opt_box_autoadd_hearing_filter(self.hearing, serializer);
+    sse_encode_urgency(self.urgency, serializer);
+  }
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat32(self);
+  }
+
+  @protected
+  void sse_encode_hearing_filter(HearingFilter self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case HearingFilter_HearingLoss():
+        sse_encode_i_32(0, serializer);
+      case HearingFilter_SuddenHearingLoss(freqHz: final freqHz):
+        sse_encode_i_32(1, serializer);
+        sse_encode_f_32(freqHz, serializer);
+      case HearingFilter_NoiseInducedHearingLoss():
+        sse_encode_i_32(2, serializer);
+      case HearingFilter_Tinnitus(freqHz: final freqHz):
+        sse_encode_i_32(3, serializer);
+        sse_encode_f_32(freqHz, serializer);
+      case HearingFilter_Hyperacusis():
+        sse_encode_i_32(4, serializer);
+      case HearingFilter_Misophonia(freqHz: final freqHz):
+        sse_encode_i_32(5, serializer);
+        sse_encode_f_32(freqHz, serializer);
+      case HearingFilter_Paracusis():
+        sse_encode_i_32(6, serializer);
+      case HearingFilter_Amusia():
+        sse_encode_i_32(7, serializer);
+      case HearingFilter_Dysmelodia():
+        sse_encode_i_32(8, serializer);
+      case HearingFilter_PitchShift(semitones: final semitones):
+        sse_encode_i_32(9, serializer);
+        sse_encode_f_32(semitones, serializer);
+      case HearingFilter_Diplacusis():
+        sse_encode_i_32(10, serializer);
+      case HearingFilter_AuditoryProcessingDisorder():
+        sse_encode_i_32(11, serializer);
+      case HearingFilter_Meniere():
+        sse_encode_i_32(12, serializer);
+      case HearingFilter_Labyrinthitis():
+        sse_encode_i_32(13, serializer);
+    }
   }
 
   @protected
@@ -670,6 +951,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_String(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_experience(
+      List<Experience> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_experience(item, serializer);
     }
   }
 
@@ -699,6 +990,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_hearing_filter(
+      HearingFilter? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_hearing_filter(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_vision_filter(
+      VisionFilter? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_vision_filter(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putUint32(self);
@@ -719,6 +1032,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_unit(void self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  void sse_encode_urgency(Urgency self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -22,16 +22,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  HearingFilter dco_decode_box_autoadd_hearing_filter(dynamic raw);
+
+  @protected
   VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw);
 
   @protected
+  Experience dco_decode_experience(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
+
+  @protected
+  HearingFilter dco_decode_hearing_filter(dynamic raw);
 
   @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<Experience> dco_decode_list_experience(dynamic raw);
 
   @protected
   Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
@@ -41,6 +53,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  HearingFilter? dco_decode_opt_box_autoadd_hearing_filter(dynamic raw);
+
+  @protected
+  VisionFilter? dco_decode_opt_box_autoadd_vision_filter(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -55,6 +73,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  Urgency dco_decode_urgency(dynamic raw);
+
+  @protected
   VisionFilter dco_decode_vision_filter(dynamic raw);
 
   @protected
@@ -64,17 +85,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  HearingFilter sse_decode_box_autoadd_hearing_filter(
+      SseDeserializer deserializer);
+
+  @protected
   VisionFilter sse_decode_box_autoadd_vision_filter(
       SseDeserializer deserializer);
 
   @protected
+  Experience sse_decode_experience(SseDeserializer deserializer);
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
+
+  @protected
+  HearingFilter sse_decode_hearing_filter(SseDeserializer deserializer);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<Experience> sse_decode_list_experience(SseDeserializer deserializer);
 
   @protected
   Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
@@ -84,6 +118,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  HearingFilter? sse_decode_opt_box_autoadd_hearing_filter(
+      SseDeserializer deserializer);
+
+  @protected
+  VisionFilter? sse_decode_opt_box_autoadd_vision_filter(
+      SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -96,6 +138,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
+
+  @protected
+  Urgency sse_decode_urgency(SseDeserializer deserializer);
 
   @protected
   VisionFilter sse_decode_vision_filter(SseDeserializer deserializer);
@@ -114,6 +159,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_hearing_filter> cst_encode_box_autoadd_hearing_filter(
+      HearingFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_hearing_filter();
+    cst_api_fill_to_wire_hearing_filter(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
   ffi.Pointer<wire_cst_vision_filter> cst_encode_box_autoadd_vision_filter(
       VisionFilter raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
@@ -128,6 +182,17 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     final ans = wire.cst_new_list_String(raw.length);
     for (var i = 0; i < raw.length; ++i) {
       ans.ref.ptr[i] = cst_encode_String(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_experience> cst_encode_list_experience(
+      List<Experience> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_experience(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_experience(raw[i], ans.ref.ptr[i]);
     }
     return ans;
   }
@@ -160,15 +225,117 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  ffi.Pointer<wire_cst_hearing_filter>
+      cst_encode_opt_box_autoadd_hearing_filter(HearingFilter? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null
+        ? ffi.nullptr
+        : cst_encode_box_autoadd_hearing_filter(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_vision_filter> cst_encode_opt_box_autoadd_vision_filter(
+      VisionFilter? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null
+        ? ffi.nullptr
+        : cst_encode_box_autoadd_vision_filter(raw);
+  }
+
+  @protected
   int cst_encode_u_64(BigInt raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw.toSigned(64).toInt();
   }
 
   @protected
+  void cst_api_fill_to_wire_box_autoadd_hearing_filter(
+      HearingFilter apiObj, ffi.Pointer<wire_cst_hearing_filter> wireObj) {
+    cst_api_fill_to_wire_hearing_filter(apiObj, wireObj.ref);
+  }
+
+  @protected
   void cst_api_fill_to_wire_box_autoadd_vision_filter(
       VisionFilter apiObj, ffi.Pointer<wire_cst_vision_filter> wireObj) {
     cst_api_fill_to_wire_vision_filter(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_experience(
+      Experience apiObj, wire_cst_experience wireObj) {
+    wireObj.id = cst_encode_String(apiObj.id);
+    wireObj.vision = cst_encode_opt_box_autoadd_vision_filter(apiObj.vision);
+    wireObj.hearing = cst_encode_opt_box_autoadd_hearing_filter(apiObj.hearing);
+    wireObj.urgency = cst_encode_urgency(apiObj.urgency);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_hearing_filter(
+      HearingFilter apiObj, wire_cst_hearing_filter wireObj) {
+    if (apiObj is HearingFilter_HearingLoss) {
+      wireObj.tag = 0;
+      return;
+    }
+    if (apiObj is HearingFilter_SuddenHearingLoss) {
+      var pre_freq_hz = cst_encode_f_32(apiObj.freqHz);
+      wireObj.tag = 1;
+      wireObj.kind.SuddenHearingLoss.freq_hz = pre_freq_hz;
+      return;
+    }
+    if (apiObj is HearingFilter_NoiseInducedHearingLoss) {
+      wireObj.tag = 2;
+      return;
+    }
+    if (apiObj is HearingFilter_Tinnitus) {
+      var pre_freq_hz = cst_encode_f_32(apiObj.freqHz);
+      wireObj.tag = 3;
+      wireObj.kind.Tinnitus.freq_hz = pre_freq_hz;
+      return;
+    }
+    if (apiObj is HearingFilter_Hyperacusis) {
+      wireObj.tag = 4;
+      return;
+    }
+    if (apiObj is HearingFilter_Misophonia) {
+      var pre_freq_hz = cst_encode_f_32(apiObj.freqHz);
+      wireObj.tag = 5;
+      wireObj.kind.Misophonia.freq_hz = pre_freq_hz;
+      return;
+    }
+    if (apiObj is HearingFilter_Paracusis) {
+      wireObj.tag = 6;
+      return;
+    }
+    if (apiObj is HearingFilter_Amusia) {
+      wireObj.tag = 7;
+      return;
+    }
+    if (apiObj is HearingFilter_Dysmelodia) {
+      wireObj.tag = 8;
+      return;
+    }
+    if (apiObj is HearingFilter_PitchShift) {
+      var pre_semitones = cst_encode_f_32(apiObj.semitones);
+      wireObj.tag = 9;
+      wireObj.kind.PitchShift.semitones = pre_semitones;
+      return;
+    }
+    if (apiObj is HearingFilter_Diplacusis) {
+      wireObj.tag = 10;
+      return;
+    }
+    if (apiObj is HearingFilter_AuditoryProcessingDisorder) {
+      wireObj.tag = 11;
+      return;
+    }
+    if (apiObj is HearingFilter_Meniere) {
+      wireObj.tag = 12;
+      return;
+    }
+    if (apiObj is HearingFilter_Labyrinthitis) {
+      wireObj.tag = 13;
+      return;
+    }
   }
 
   @protected
@@ -356,23 +523,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_encode_unit(void raw);
 
   @protected
+  int cst_encode_urgency(Urgency raw);
+
+  @protected
   int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_hearing_filter(
+      HearingFilter self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_vision_filter(
       VisionFilter self, SseSerializer serializer);
 
   @protected
+  void sse_encode_experience(Experience self, SseSerializer serializer);
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_hearing_filter(HearingFilter self, SseSerializer serializer);
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_experience(
+      List<Experience> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_f_32_strict(
@@ -386,6 +570,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       Uint8List self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_hearing_filter(
+      HearingFilter? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_vision_filter(
+      VisionFilter? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
 
   @protected
@@ -396,6 +588,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_urgency(Urgency self, SseSerializer serializer);
 
   @protected
   void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer);
@@ -483,6 +678,18 @@ class RustLibWire implements BaseWire {
             double,
           )>();
 
+  WireSyncRust2DartDco wire__crate__api__sensus_bridge__experiences() {
+    return _wire__crate__api__sensus_bridge__experiences();
+  }
+
+  late final _wire__crate__api__sensus_bridge__experiencesPtr =
+      _lookup<ffi.NativeFunction<WireSyncRust2DartDco Function()>>(
+    'frbgen_universal_experience_wire__crate__api__sensus_bridge__experiences',
+  );
+  late final _wire__crate__api__sensus_bridge__experiences =
+      _wire__crate__api__sensus_bridge__experiencesPtr
+          .asFunction<WireSyncRust2DartDco Function()>();
+
   WireSyncRust2DartDco wire__crate__api__sensus_bridge__vision_shader_glsl(
     ffi.Pointer<wire_cst_vision_filter> filter,
   ) {
@@ -552,6 +759,17 @@ class RustLibWire implements BaseWire {
             int,
           )>();
 
+  ffi.Pointer<wire_cst_hearing_filter> cst_new_box_autoadd_hearing_filter() {
+    return _cst_new_box_autoadd_hearing_filter();
+  }
+
+  late final _cst_new_box_autoadd_hearing_filterPtr = _lookup<
+          ffi.NativeFunction<ffi.Pointer<wire_cst_hearing_filter> Function()>>(
+      'frbgen_universal_experience_cst_new_box_autoadd_hearing_filter');
+  late final _cst_new_box_autoadd_hearing_filter =
+      _cst_new_box_autoadd_hearing_filterPtr
+          .asFunction<ffi.Pointer<wire_cst_hearing_filter> Function()>();
+
   ffi.Pointer<wire_cst_vision_filter> cst_new_box_autoadd_vision_filter() {
     return _cst_new_box_autoadd_vision_filter();
   }
@@ -573,6 +791,17 @@ class RustLibWire implements BaseWire {
               ffi.Int32)>>('frbgen_universal_experience_cst_new_list_String');
   late final _cst_new_list_String = _cst_new_list_StringPtr
       .asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_experience> cst_new_list_experience(int len) {
+    return _cst_new_list_experience(len);
+  }
+
+  late final _cst_new_list_experiencePtr = _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<wire_cst_list_experience> Function(ffi.Int32)>>(
+      'frbgen_universal_experience_cst_new_list_experience');
+  late final _cst_new_list_experience = _cst_new_list_experiencePtr
+      .asFunction<ffi.Pointer<wire_cst_list_experience> Function(int)>();
 
   ffi.Pointer<wire_cst_list_prim_f_32_strict> cst_new_list_prim_f_32_strict(
     int len,
@@ -760,6 +989,43 @@ final class wire_cst_list_prim_u_8_loose extends ffi.Struct {
   external int len;
 }
 
+final class wire_cst_HearingFilter_SuddenHearingLoss extends ffi.Struct {
+  @ffi.Float()
+  external double freq_hz;
+}
+
+final class wire_cst_HearingFilter_Tinnitus extends ffi.Struct {
+  @ffi.Float()
+  external double freq_hz;
+}
+
+final class wire_cst_HearingFilter_Misophonia extends ffi.Struct {
+  @ffi.Float()
+  external double freq_hz;
+}
+
+final class wire_cst_HearingFilter_PitchShift extends ffi.Struct {
+  @ffi.Float()
+  external double semitones;
+}
+
+final class HearingFilterKind extends ffi.Union {
+  external wire_cst_HearingFilter_SuddenHearingLoss SuddenHearingLoss;
+
+  external wire_cst_HearingFilter_Tinnitus Tinnitus;
+
+  external wire_cst_HearingFilter_Misophonia Misophonia;
+
+  external wire_cst_HearingFilter_PitchShift PitchShift;
+}
+
+final class wire_cst_hearing_filter extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external HearingFilterKind kind;
+}
+
 final class wire_cst_list_prim_u_8_strict extends ffi.Struct {
   external ffi.Pointer<ffi.Uint8> ptr;
 
@@ -769,6 +1035,24 @@ final class wire_cst_list_prim_u_8_strict extends ffi.Struct {
 
 final class wire_cst_list_String extends ffi.Struct {
   external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_experience extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> id;
+
+  external ffi.Pointer<wire_cst_vision_filter> vision;
+
+  external ffi.Pointer<wire_cst_hearing_filter> hearing;
+
+  @ffi.Int32()
+  external int urgency;
+}
+
+final class wire_cst_list_experience extends ffi.Struct {
+  external ffi.Pointer<wire_cst_experience> ptr;
 
   @ffi.Int32()
   external int len;

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -24,16 +24,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  HearingFilter dco_decode_box_autoadd_hearing_filter(dynamic raw);
+
+  @protected
   VisionFilter dco_decode_box_autoadd_vision_filter(dynamic raw);
 
   @protected
+  Experience dco_decode_experience(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
+
+  @protected
+  HearingFilter dco_decode_hearing_filter(dynamic raw);
 
   @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<Experience> dco_decode_list_experience(dynamic raw);
 
   @protected
   Float32List dco_decode_list_prim_f_32_strict(dynamic raw);
@@ -43,6 +55,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  HearingFilter? dco_decode_opt_box_autoadd_hearing_filter(dynamic raw);
+
+  @protected
+  VisionFilter? dco_decode_opt_box_autoadd_vision_filter(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -57,6 +75,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  Urgency dco_decode_urgency(dynamic raw);
+
+  @protected
   VisionFilter dco_decode_vision_filter(dynamic raw);
 
   @protected
@@ -66,17 +87,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  HearingFilter sse_decode_box_autoadd_hearing_filter(
+      SseDeserializer deserializer);
+
+  @protected
   VisionFilter sse_decode_box_autoadd_vision_filter(
       SseDeserializer deserializer);
 
   @protected
+  Experience sse_decode_experience(SseDeserializer deserializer);
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
+
+  @protected
+  HearingFilter sse_decode_hearing_filter(SseDeserializer deserializer);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<Experience> sse_decode_list_experience(SseDeserializer deserializer);
 
   @protected
   Float32List sse_decode_list_prim_f_32_strict(SseDeserializer deserializer);
@@ -86,6 +120,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  HearingFilter? sse_decode_opt_box_autoadd_hearing_filter(
+      SseDeserializer deserializer);
+
+  @protected
+  VisionFilter? sse_decode_opt_box_autoadd_vision_filter(
+      SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -98,6 +140,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
+
+  @protected
+  Urgency sse_decode_urgency(SseDeserializer deserializer);
 
   @protected
   VisionFilter sse_decode_vision_filter(SseDeserializer deserializer);
@@ -116,15 +161,87 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  JSAny cst_encode_box_autoadd_hearing_filter(HearingFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_hearing_filter(raw);
+  }
+
+  @protected
   JSAny cst_encode_box_autoadd_vision_filter(VisionFilter raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return cst_encode_vision_filter(raw);
   }
 
   @protected
+  JSAny cst_encode_experience(Experience raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_String(raw.id),
+      cst_encode_opt_box_autoadd_vision_filter(raw.vision),
+      cst_encode_opt_box_autoadd_hearing_filter(raw.hearing),
+      cst_encode_urgency(raw.urgency)
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_hearing_filter(HearingFilter raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    if (raw is HearingFilter_HearingLoss) {
+      return [0].jsify()!;
+    }
+    if (raw is HearingFilter_SuddenHearingLoss) {
+      return [1, cst_encode_f_32(raw.freqHz)].jsify()!;
+    }
+    if (raw is HearingFilter_NoiseInducedHearingLoss) {
+      return [2].jsify()!;
+    }
+    if (raw is HearingFilter_Tinnitus) {
+      return [3, cst_encode_f_32(raw.freqHz)].jsify()!;
+    }
+    if (raw is HearingFilter_Hyperacusis) {
+      return [4].jsify()!;
+    }
+    if (raw is HearingFilter_Misophonia) {
+      return [5, cst_encode_f_32(raw.freqHz)].jsify()!;
+    }
+    if (raw is HearingFilter_Paracusis) {
+      return [6].jsify()!;
+    }
+    if (raw is HearingFilter_Amusia) {
+      return [7].jsify()!;
+    }
+    if (raw is HearingFilter_Dysmelodia) {
+      return [8].jsify()!;
+    }
+    if (raw is HearingFilter_PitchShift) {
+      return [9, cst_encode_f_32(raw.semitones)].jsify()!;
+    }
+    if (raw is HearingFilter_Diplacusis) {
+      return [10].jsify()!;
+    }
+    if (raw is HearingFilter_AuditoryProcessingDisorder) {
+      return [11].jsify()!;
+    }
+    if (raw is HearingFilter_Meniere) {
+      return [12].jsify()!;
+    }
+    if (raw is HearingFilter_Labyrinthitis) {
+      return [13].jsify()!;
+    }
+
+    throw Exception('unreachable');
+  }
+
+  @protected
   JSAny cst_encode_list_String(List<String> raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw.map(cst_encode_String).toList().jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_list_experience(List<Experience> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_experience).toList().jsify()!;
   }
 
   @protected
@@ -143,6 +260,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   JSAny cst_encode_list_prim_u_8_strict(Uint8List raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw.jsify()!;
+  }
+
+  @protected
+  JSAny? cst_encode_opt_box_autoadd_hearing_filter(HearingFilter? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_box_autoadd_hearing_filter(raw);
+  }
+
+  @protected
+  JSAny? cst_encode_opt_box_autoadd_vision_filter(VisionFilter? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_box_autoadd_vision_filter(raw);
   }
 
   @protected
@@ -287,23 +416,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_encode_unit(void raw);
 
   @protected
+  int cst_encode_urgency(Urgency raw);
+
+  @protected
   int cst_encode_vision_glaucoma_mode(VisionGlaucomaMode raw);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_hearing_filter(
+      HearingFilter self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_vision_filter(
       VisionFilter self, SseSerializer serializer);
 
   @protected
+  void sse_encode_experience(Experience self, SseSerializer serializer);
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_hearing_filter(HearingFilter self, SseSerializer serializer);
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_experience(
+      List<Experience> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_f_32_strict(
@@ -317,6 +463,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       Uint8List self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_hearing_filter(
+      HearingFilter? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_vision_filter(
+      VisionFilter? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
 
   @protected
@@ -327,6 +481,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_urgency(Urgency self, SseSerializer serializer);
 
   @protected
   void sse_encode_vision_filter(VisionFilter self, SseSerializer serializer);
@@ -349,6 +506,10 @@ class RustLibWire implements BaseWire {
               JSAny rgba8, int width, int height, double strength) =>
           wasmModule.wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
               filter, rgba8, width, height, strength);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__experiences() =>
+          wasmModule.wire__crate__api__sensus_bridge__experiences();
 
   JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
       wire__crate__api__sensus_bridge__vision_shader_glsl(JSAny filter) =>
@@ -376,6 +537,9 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
   external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
       wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8(
           JSAny filter, JSAny rgba8, int width, int height, double strength);
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+      wire__crate__api__sensus_bridge__experiences();
 
   external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
       wire__crate__api__sensus_bridge__vision_shader_glsl(JSAny filter);

--- a/rust/src/api/sensus_bridge.rs
+++ b/rust/src/api/sensus_bridge.rs
@@ -53,6 +53,16 @@ impl VisionGlaucomaMode {
             VisionGlaucomaMode::Biarcuate => G::Biarcuate,
         }
     }
+
+    fn from_sensus(mode: sensus_core::vision::GlaucomaMode) -> Self {
+        use sensus_core::vision::GlaucomaMode as G;
+        match mode {
+            G::Vignette => VisionGlaucomaMode::Vignette,
+            G::ArcuateSuperior => VisionGlaucomaMode::ArcuateSuperior,
+            G::ArcuateInferior => VisionGlaucomaMode::ArcuateInferior,
+            G::Biarcuate => VisionGlaucomaMode::Biarcuate,
+        }
+    }
 }
 
 /// Dart 側で扱う vision フィルタ。`sensus_core::Filter` の vision バリアント全種を
@@ -233,6 +243,87 @@ impl VisionFilter {
             VisionFilter::Teichopsia => F::Teichopsia,
             VisionFilter::FlickeringStars { seed } => F::FlickeringStars { seed },
         }
+    }
+
+    /// `sensus_core::Filter` を Dart 公開ミラーへ逆変換する。`to_sensus` の対称写像。
+    ///
+    /// sensus の `Filter` は全 vision バリアントなので（聴覚は別 enum `HearingFilter`）、
+    /// 本関数は常に `Some` を返す。戻り値を `Option` にしてあるのは、将来 sensus が
+    /// non-vision な `Filter` バリアントを足したときに `None` で逃がせるようにするため。
+    /// [`Experience`] の `vision: Option<Filter>` をミラーへ写す際に使う。
+    fn from_sensus(filter: sensus_core::Filter) -> Option<VisionFilter> {
+        use sensus_core::Filter as F;
+        let mirror = match filter {
+            F::Protanopia => VisionFilter::Protanopia,
+            F::Deuteranopia => VisionFilter::Deuteranopia,
+            F::Tritanopia => VisionFilter::Tritanopia,
+            F::Achromatopsia => VisionFilter::Achromatopsia,
+            F::Tetrachromacy => VisionFilter::Tetrachromacy,
+            F::Myopia => VisionFilter::Myopia,
+            F::Hyperopia => VisionFilter::Hyperopia,
+            F::Presbyopia => VisionFilter::Presbyopia,
+            F::Astigmatism { axis_deg } => VisionFilter::Astigmatism { axis_deg },
+            F::Glaucoma { mode } => VisionFilter::Glaucoma {
+                mode: VisionGlaucomaMode::from_sensus(mode),
+            },
+            F::MacularDegeneration => VisionFilter::MacularDegeneration,
+            F::Hemianopia { side } => VisionFilter::Hemianopia { side },
+            F::TunnelVision => VisionFilter::TunnelVision,
+            F::Cataract { seed } => VisionFilter::Cataract { seed },
+            F::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            } => VisionFilter::Floaters {
+                seed,
+                density,
+                size,
+                gaze_x,
+                gaze_y,
+            },
+            F::Photophobia => VisionFilter::Photophobia,
+            F::NightBlindness => VisionFilter::NightBlindness,
+            F::Vertigo => VisionFilter::Vertigo,
+            F::BppvRotation => VisionFilter::BppvRotation,
+            F::VestibularNeuritis => VisionFilter::VestibularNeuritis,
+            F::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            } => VisionFilter::Diplopia {
+                offset_x,
+                offset_y,
+                ghost_strength,
+            },
+            F::Nystagmus {
+                amplitude,
+                direction_deg,
+            } => VisionFilter::Nystagmus {
+                amplitude,
+                direction_deg,
+            },
+            F::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            } => VisionFilter::Starbursts {
+                num_rays,
+                ray_length_ratio,
+                threshold,
+                dispersion,
+            },
+            F::EyeStrain => VisionFilter::EyeStrain,
+            F::DryEye => VisionFilter::DryEye,
+            F::Metamorphopsia { freq, seed } => VisionFilter::Metamorphopsia { freq, seed },
+            F::ContrastSensitivity => VisionFilter::ContrastSensitivity,
+            F::DetailLoss { cell_size } => VisionFilter::DetailLoss { cell_size },
+            F::Teichopsia => VisionFilter::Teichopsia,
+            F::FlickeringStars { seed } => VisionFilter::FlickeringStars { seed },
+        };
+        Some(mirror)
     }
 }
 
@@ -654,6 +745,158 @@ pub fn apply_vision_cpu_rgba8(
     Ok(out.to_rgba8().into_raw())
 }
 
+// =============================================================================
+// 体験（Experience）— 視覚 + 聴覚 + 緊急度の正準記述子
+// =============================================================================
+//
+// sensus-core の `Experience` / `Urgency` / `HearingFilter` を Dart へ公開する。
+// 文言（体験名・緊急度メッセージ・聴覚症状の説明）は **一切持たせない**。`id` と
+// 分類（enum バリアント）だけを出し、文言は ue 側 i18n（#18）が `id`・urgency 種別・
+// HearingFilter バリアントをキーに解決する。これにより、文言の正本は ue（多言語）、
+// 症状の組み合わせ（三徴候の正準化）の正本は sensus-core、と責務が分かれる。
+//
+// HearingFilter は **型として公開するだけ**で、音声再生は本層のスコープ外（#19 の
+// 聴覚モード設計に委ねる）。ここでは Experience の `hearing` データ（どの聴覚フィルタが
+// 組になるか）と 14 バリアントの識別子を Dart に渡すところまでを担う。
+
+/// 受診喚起の緊急度分類。`sensus_core::Urgency` の FRB 公開ミラー。
+///
+/// 文言は持たない（分類のみ）。⚠️/🚨 等の表示文言は Dart 側 i18n が
+/// このバリアントをキーに出し分ける。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Urgency {
+    /// 緊急性の注記なし。
+    None,
+    /// 早期受診が望ましい。
+    EarlyConsultation,
+    /// 即救急（脳卒中等のサインの可能性）。
+    Emergency,
+}
+
+impl Urgency {
+    fn from_sensus(urgency: sensus_core::Urgency) -> Self {
+        use sensus_core::Urgency as U;
+        match urgency {
+            U::None => Urgency::None,
+            U::EarlyConsultation => Urgency::EarlyConsultation,
+            U::Emergency => Urgency::Emergency,
+        }
+    }
+}
+
+/// 聴覚フィルタの種類。`sensus_core::HearingFilter` の FRB 公開ミラー（14 バリアント）。
+///
+/// **型として公開するだけ**で、音声再生（`apply_hearing` 相当）は本層のスコープ外
+/// （聴覚モード設計 #19 に委ねる）。payload 付きバリアントは sensus と同じフィールド名・
+/// 型（`{ freq_hz: f32 }` 等）でミラーする。症状の説明文言は持たず、Dart 側 i18n が
+/// バリアントをキーに解決する。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum HearingFilter {
+    /// 難聴: 高音域カット。
+    HearingLoss,
+    /// 突発性難聴: 特定周波数帯の急激な損失。
+    SuddenHearingLoss { freq_hz: f32 },
+    /// 騒音性難聴: 4 kHz 付近の損失。
+    NoiseInducedHearingLoss,
+    /// 耳鳴り: 指定周波数の正弦波を常時ミックス。
+    Tinnitus { freq_hz: f32 },
+    /// 音響過敏: 音量を異常に増幅。
+    Hyperacusis,
+    /// ミソフォニア: `freq_hz` 中心のトリガー帯域を過剰増幅 + 歪み。
+    Misophonia { freq_hz: f32 },
+    /// 変音: 音を歪んだ・金属的な質感に加工。
+    Paracusis,
+    /// 音楽音痴: 音程の違いを識別しにくくする。
+    Amusia,
+    /// ジスメロディア: 音楽を不快・歪んだ音に変換。
+    Dysmelodia,
+    /// 音程シフト: 半音単位で全体音程をシフト。
+    PitchShift { semitones: f32 },
+    /// ダイプラクシス: 左右耳で異なる音程を知覚。
+    Diplacusis,
+    /// APD（聴覚情報処理障害）: 時間分解能低下 + 雑音付加。
+    AuditoryProcessingDisorder,
+    /// メニエール病の聴覚側: 低音域難聴 + 低い唸る耳鳴り。
+    Meniere,
+    /// 迷路炎の聴覚側: 高音域感音難聴 + 高音の耳鳴り。
+    Labyrinthitis,
+}
+
+impl HearingFilter {
+    fn from_sensus(filter: sensus_core::HearingFilter) -> Self {
+        use sensus_core::HearingFilter as H;
+        match filter {
+            H::HearingLoss => HearingFilter::HearingLoss,
+            H::SuddenHearingLoss { freq_hz } => HearingFilter::SuddenHearingLoss { freq_hz },
+            H::NoiseInducedHearingLoss => HearingFilter::NoiseInducedHearingLoss,
+            H::Tinnitus { freq_hz } => HearingFilter::Tinnitus { freq_hz },
+            H::Hyperacusis => HearingFilter::Hyperacusis,
+            H::Misophonia { freq_hz } => HearingFilter::Misophonia { freq_hz },
+            H::Paracusis => HearingFilter::Paracusis,
+            H::Amusia => HearingFilter::Amusia,
+            H::Dysmelodia => HearingFilter::Dysmelodia,
+            H::PitchShift { semitones } => HearingFilter::PitchShift { semitones },
+            H::Diplacusis => HearingFilter::Diplacusis,
+            H::AuditoryProcessingDisorder => HearingFilter::AuditoryProcessingDisorder,
+            H::Meniere => HearingFilter::Meniere,
+            H::Labyrinthitis => HearingFilter::Labyrinthitis,
+        }
+    }
+}
+
+/// 視覚 + 聴覚にまたがる「複合体験」の Dart 公開ミラー。`sensus_core::Experience` 由来。
+///
+/// sensus は pure・別バッファ（画像 / 音声）のため、メニエール病のような「回転性めまい
+/// （視覚）＋ 難聴・耳鳴り（聴覚）」の複合症状を 1 バッファで表せない。`Experience` は
+/// 「どの視覚フィルタとどの聴覚フィルタを組にすれば仕様どおりの複合体験になるか」の
+/// 正準化を sensus から受け取る。Dart 側は三徴候の組み合わせをハードコードせず、
+/// [`experiences`] から取得する。
+///
+/// `id` は安定した英語識別子（i18n キー）。文言（体験名・説明）は持たず、Dart 側 i18n が
+/// `id` をキーに解決する。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Experience {
+    /// 安定した識別子（i18n キー等に使う英語 ID）。sensus は `&'static str` だが
+    /// FRB は `String` で出す。
+    pub id: String,
+    /// 視覚側フィルタ（視覚要素が無い体験では `None`）。
+    pub vision: Option<VisionFilter>,
+    /// 聴覚側フィルタ（聴覚要素が無い体験では `None`）。
+    pub hearing: Option<HearingFilter>,
+    /// 受診喚起の緊急度。
+    pub urgency: Urgency,
+}
+
+impl Experience {
+    fn from_sensus(exp: &sensus_core::Experience) -> Self {
+        Experience {
+            id: exp.id.to_string(),
+            vision: exp.vision.and_then(VisionFilter::from_sensus),
+            hearing: exp.hearing.clone().map(HearingFilter::from_sensus),
+            urgency: Urgency::from_sensus(exp.urgency),
+        }
+    }
+}
+
+/// sensus-core が正準化した複合体験のプリセット 4 種を Dart へ返す。
+///
+/// 順序固定: meniere / bppv / vestibular_neuritis / labyrinthitis。各体験の視覚・聴覚
+/// フィルタと緊急度は sensus の `Experience::MENIERE` 等の const をミラーへ変換したもの。
+/// 文言は含まない（`id`・分類のみ）。体験名・緊急度メッセージ・聴覚症状の説明は
+/// Dart 側 i18n（#18）が解決する。
+#[flutter_rust_bridge::frb(sync)]
+pub fn experiences() -> Vec<Experience> {
+    [
+        &sensus_core::Experience::MENIERE,
+        &sensus_core::Experience::BPPV,
+        &sensus_core::Experience::VESTIBULAR_NEURITIS,
+        &sensus_core::Experience::LABYRINTHITIS,
+    ]
+    .into_iter()
+    .map(Experience::from_sensus)
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1004,5 +1247,99 @@ mod tests {
         assert_eq!(u[3], 8.0); // uNumRays
                                // ray_length_px = (0.1 * min(200,100)) as u32 = 10
         assert_eq!(u[4], 10.0);
+    }
+
+    // --- Experience / Urgency / HearingFilter ミラーのマッピング検証 ---
+
+    /// experiences() は sensus の 4 プリセットを順序固定で返す。
+    #[test]
+    fn experiences_returns_four_presets_in_order() {
+        let xs = experiences();
+        assert_eq!(xs.len(), 4);
+        let ids: Vec<&str> = xs.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["meniere", "bppv", "vestibular_neuritis", "labyrinthitis"]
+        );
+    }
+
+    /// meniere = 回転性めまい（視覚 Vertigo）+ 聴覚 Meniere + 早期受診。
+    #[test]
+    fn meniere_maps_vision_hearing_urgency() {
+        let xs = experiences();
+        let m = xs.iter().find(|e| e.id == "meniere").unwrap();
+        assert_eq!(m.vision, Some(VisionFilter::Vertigo));
+        assert_eq!(m.hearing, Some(HearingFilter::Meniere));
+        assert_eq!(m.urgency, Urgency::EarlyConsultation);
+    }
+
+    /// bppv = 純粋な前庭性めまい（聴覚症状なし）+ 緊急度なし。
+    #[test]
+    fn bppv_has_no_hearing_and_no_urgency() {
+        let xs = experiences();
+        let b = xs.iter().find(|e| e.id == "bppv").unwrap();
+        assert_eq!(b.vision, Some(VisionFilter::BppvRotation));
+        assert_eq!(b.hearing, None);
+        assert_eq!(b.urgency, Urgency::None);
+    }
+
+    /// vestibular_neuritis = 聴力温存（hearing None）+ 突然発症で救急。
+    #[test]
+    fn vestibular_neuritis_is_emergency_with_no_hearing() {
+        let xs = experiences();
+        let v = xs.iter().find(|e| e.id == "vestibular_neuritis").unwrap();
+        assert_eq!(v.vision, Some(VisionFilter::VestibularNeuritis));
+        assert_eq!(v.hearing, None);
+        assert_eq!(v.urgency, Urgency::Emergency);
+    }
+
+    /// labyrinthitis = 回転性めまい（視覚 Vertigo）+ 聴覚 Labyrinthitis + 早期受診。
+    #[test]
+    fn labyrinthitis_maps_vision_hearing_urgency() {
+        let xs = experiences();
+        let l = xs.iter().find(|e| e.id == "labyrinthitis").unwrap();
+        assert_eq!(l.vision, Some(VisionFilter::Vertigo));
+        assert_eq!(l.hearing, Some(HearingFilter::Labyrinthitis));
+        assert_eq!(l.urgency, Urgency::EarlyConsultation);
+    }
+
+    /// Urgency ミラーが sensus の 3 バリアントと 1 対 1 対応する。
+    #[test]
+    fn urgency_from_sensus_covers_all_variants() {
+        use sensus_core::Urgency as U;
+        assert_eq!(Urgency::from_sensus(U::None), Urgency::None);
+        assert_eq!(
+            Urgency::from_sensus(U::EarlyConsultation),
+            Urgency::EarlyConsultation
+        );
+        assert_eq!(Urgency::from_sensus(U::Emergency), Urgency::Emergency);
+    }
+
+    /// HearingFilter ミラーが payload を保持して写す（代表バリアント）。
+    #[test]
+    fn hearing_filter_from_sensus_preserves_payload() {
+        use sensus_core::HearingFilter as H;
+        assert_eq!(
+            HearingFilter::from_sensus(H::Tinnitus { freq_hz: 4000.0 }),
+            HearingFilter::Tinnitus { freq_hz: 4000.0 }
+        );
+        assert_eq!(
+            HearingFilter::from_sensus(H::PitchShift { semitones: -2.0 }),
+            HearingFilter::PitchShift { semitones: -2.0 }
+        );
+        assert_eq!(
+            HearingFilter::from_sensus(H::HearingLoss),
+            HearingFilter::HearingLoss
+        );
+        assert_eq!(HearingFilter::from_sensus(H::Meniere), HearingFilter::Meniere);
+    }
+
+    /// VisionFilter::from_sensus は to_sensus の逆写像（payload 付き含む代表ラウンドトリップ）。
+    #[test]
+    fn vision_filter_from_sensus_roundtrips_to_sensus() {
+        for f in ALL_FILTERS {
+            let back = VisionFilter::from_sensus(f.to_sensus());
+            assert_eq!(back, Some(f), "{f:?}: from_sensus(to_sensus) mismatch");
+        }
     }
 }

--- a/rust/src/api/sensus_bridge.rs
+++ b/rust/src/api/sensus_bridge.rs
@@ -1331,7 +1331,10 @@ mod tests {
             HearingFilter::from_sensus(H::HearingLoss),
             HearingFilter::HearingLoss
         );
-        assert_eq!(HearingFilter::from_sensus(H::Meniere), HearingFilter::Meniere);
+        assert_eq!(
+            HearingFilter::from_sensus(H::Meniere),
+            HearingFilter::Meniere
+        );
     }
 
     /// VisionFilter::from_sensus は to_sensus の逆写像（payload 付き含む代表ラウンドトリップ）。

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -166308027;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -326563465;
 
 // Section: executor
 
@@ -72,6 +72,22 @@ fn wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8_impl(
                     api_height,
                     api_strength,
                 )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sensus_bridge__experiences_impl(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "experiences",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            transform_result_dco::<_, _, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::sensus_bridge::experiences())?;
                 Ok(output_ok)
             })())
         },
@@ -181,6 +197,17 @@ impl CstDecode<u8> for u8 {
         self
     }
 }
+impl CstDecode<crate::api::sensus_bridge::Urgency> for i32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::sensus_bridge::Urgency {
+        match self {
+            0 => crate::api::sensus_bridge::Urgency::None,
+            1 => crate::api::sensus_bridge::Urgency::EarlyConsultation,
+            2 => crate::api::sensus_bridge::Urgency::Emergency,
+            _ => unreachable!("Invalid variant for Urgency: {}", self),
+        }
+    }
+}
 impl CstDecode<crate::api::sensus_bridge::VisionGlaucomaMode> for i32 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::api::sensus_bridge::VisionGlaucomaMode {
@@ -201,10 +228,94 @@ impl SseDecode for String {
     }
 }
 
+impl SseDecode for crate::api::sensus_bridge::Experience {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_vision =
+            <Option<crate::api::sensus_bridge::VisionFilter>>::sse_decode(deserializer);
+        let mut var_hearing =
+            <Option<crate::api::sensus_bridge::HearingFilter>>::sse_decode(deserializer);
+        let mut var_urgency = <crate::api::sensus_bridge::Urgency>::sse_decode(deserializer);
+        return crate::api::sensus_bridge::Experience {
+            id: var_id,
+            vision: var_vision,
+            hearing: var_hearing,
+            urgency: var_urgency,
+        };
+    }
+}
+
 impl SseDecode for f32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_f32::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for crate::api::sensus_bridge::HearingFilter {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::sensus_bridge::HearingFilter::HearingLoss;
+            }
+            1 => {
+                let mut var_freqHz = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::HearingFilter::SuddenHearingLoss {
+                    freq_hz: var_freqHz,
+                };
+            }
+            2 => {
+                return crate::api::sensus_bridge::HearingFilter::NoiseInducedHearingLoss;
+            }
+            3 => {
+                let mut var_freqHz = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::HearingFilter::Tinnitus {
+                    freq_hz: var_freqHz,
+                };
+            }
+            4 => {
+                return crate::api::sensus_bridge::HearingFilter::Hyperacusis;
+            }
+            5 => {
+                let mut var_freqHz = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::HearingFilter::Misophonia {
+                    freq_hz: var_freqHz,
+                };
+            }
+            6 => {
+                return crate::api::sensus_bridge::HearingFilter::Paracusis;
+            }
+            7 => {
+                return crate::api::sensus_bridge::HearingFilter::Amusia;
+            }
+            8 => {
+                return crate::api::sensus_bridge::HearingFilter::Dysmelodia;
+            }
+            9 => {
+                let mut var_semitones = <f32>::sse_decode(deserializer);
+                return crate::api::sensus_bridge::HearingFilter::PitchShift {
+                    semitones: var_semitones,
+                };
+            }
+            10 => {
+                return crate::api::sensus_bridge::HearingFilter::Diplacusis;
+            }
+            11 => {
+                return crate::api::sensus_bridge::HearingFilter::AuditoryProcessingDisorder;
+            }
+            12 => {
+                return crate::api::sensus_bridge::HearingFilter::Meniere;
+            }
+            13 => {
+                return crate::api::sensus_bridge::HearingFilter::Labyrinthitis;
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -222,6 +333,20 @@ impl SseDecode for Vec<String> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::sensus_bridge::Experience> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::sensus_bridge::Experience>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -251,6 +376,32 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Option<crate::api::sensus_bridge::HearingFilter> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::sensus_bridge::HearingFilter>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::sensus_bridge::VisionFilter> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::sensus_bridge::VisionFilter>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -275,6 +426,19 @@ impl SseDecode for u8 {
 impl SseDecode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {}
+}
+
+impl SseDecode for crate::api::sensus_bridge::Urgency {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::sensus_bridge::Urgency::None,
+            1 => crate::api::sensus_bridge::Urgency::EarlyConsultation,
+            2 => crate::api::sensus_bridge::Urgency::Emergency,
+            _ => unreachable!("Invalid variant for Urgency: {}", inner),
+        };
+    }
 }
 
 impl SseDecode for crate::api::sensus_bridge::VisionFilter {
@@ -476,6 +640,98 @@ fn pde_ffi_dispatcher_sync_impl(
 // Section: rust2dart
 
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::Experience {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.vision.into_into_dart().into_dart(),
+            self.hearing.into_into_dart().into_dart(),
+            self.urgency.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sensus_bridge::Experience
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sensus_bridge::Experience>
+    for crate::api::sensus_bridge::Experience
+{
+    fn into_into_dart(self) -> crate::api::sensus_bridge::Experience {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::HearingFilter {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::sensus_bridge::HearingFilter::HearingLoss => [0.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::SuddenHearingLoss { freq_hz } => {
+                [1.into_dart(), freq_hz.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::NoiseInducedHearingLoss => {
+                [2.into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::Tinnitus { freq_hz } => {
+                [3.into_dart(), freq_hz.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::Hyperacusis => [4.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::Misophonia { freq_hz } => {
+                [5.into_dart(), freq_hz.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::Paracusis => [6.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::Amusia => [7.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::Dysmelodia => [8.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::PitchShift { semitones } => {
+                [9.into_dart(), semitones.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::Diplacusis => [10.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::AuditoryProcessingDisorder => {
+                [11.into_dart()].into_dart()
+            }
+            crate::api::sensus_bridge::HearingFilter::Meniere => [12.into_dart()].into_dart(),
+            crate::api::sensus_bridge::HearingFilter::Labyrinthitis => [13.into_dart()].into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sensus_bridge::HearingFilter
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sensus_bridge::HearingFilter>
+    for crate::api::sensus_bridge::HearingFilter
+{
+    fn into_into_dart(self) -> crate::api::sensus_bridge::HearingFilter {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::Urgency {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::None => 0.into_dart(),
+            Self::EarlyConsultation => 1.into_dart(),
+            Self::Emergency => 2.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sensus_bridge::Urgency
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sensus_bridge::Urgency>
+    for crate::api::sensus_bridge::Urgency
+{
+    fn into_into_dart(self) -> crate::api::sensus_bridge::Urgency {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sensus_bridge::VisionFilter {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -624,10 +880,77 @@ impl SseEncode for String {
     }
 }
 
+impl SseEncode for crate::api::sensus_bridge::Experience {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+        <Option<crate::api::sensus_bridge::VisionFilter>>::sse_encode(self.vision, serializer);
+        <Option<crate::api::sensus_bridge::HearingFilter>>::sse_encode(self.hearing, serializer);
+        <crate::api::sensus_bridge::Urgency>::sse_encode(self.urgency, serializer);
+    }
+}
+
 impl SseEncode for f32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_f32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for crate::api::sensus_bridge::HearingFilter {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::sensus_bridge::HearingFilter::HearingLoss => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::SuddenHearingLoss { freq_hz } => {
+                <i32>::sse_encode(1, serializer);
+                <f32>::sse_encode(freq_hz, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::NoiseInducedHearingLoss => {
+                <i32>::sse_encode(2, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Tinnitus { freq_hz } => {
+                <i32>::sse_encode(3, serializer);
+                <f32>::sse_encode(freq_hz, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Hyperacusis => {
+                <i32>::sse_encode(4, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Misophonia { freq_hz } => {
+                <i32>::sse_encode(5, serializer);
+                <f32>::sse_encode(freq_hz, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Paracusis => {
+                <i32>::sse_encode(6, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Amusia => {
+                <i32>::sse_encode(7, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Dysmelodia => {
+                <i32>::sse_encode(8, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::PitchShift { semitones } => {
+                <i32>::sse_encode(9, serializer);
+                <f32>::sse_encode(semitones, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Diplacusis => {
+                <i32>::sse_encode(10, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::AuditoryProcessingDisorder => {
+                <i32>::sse_encode(11, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Meniere => {
+                <i32>::sse_encode(12, serializer);
+            }
+            crate::api::sensus_bridge::HearingFilter::Labyrinthitis => {
+                <i32>::sse_encode(13, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -648,6 +971,16 @@ impl SseEncode for Vec<String> {
     }
 }
 
+impl SseEncode for Vec<crate::api::sensus_bridge::Experience> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::sensus_bridge::Experience>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<f32> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -664,6 +997,26 @@ impl SseEncode for Vec<u8> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <u8>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::sensus_bridge::HearingFilter> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::sensus_bridge::HearingFilter>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::sensus_bridge::VisionFilter> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::sensus_bridge::VisionFilter>::sse_encode(value, serializer);
         }
     }
 }
@@ -692,6 +1045,23 @@ impl SseEncode for u8 {
 impl SseEncode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {}
+}
+
+impl SseEncode for crate::api::sensus_bridge::Urgency {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::sensus_bridge::Urgency::None => 0,
+                crate::api::sensus_bridge::Urgency::EarlyConsultation => 1,
+                crate::api::sensus_bridge::Urgency::Emergency => 2,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
 }
 
 impl SseEncode for crate::api::sensus_bridge::VisionFilter {
@@ -887,6 +1257,13 @@ mod io {
             String::from_utf8(vec).unwrap()
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::HearingFilter> for *mut wire_cst_hearing_filter {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::HearingFilter {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::api::sensus_bridge::HearingFilter>::cst_decode(*wrap).into()
+        }
+    }
     impl CstDecode<crate::api::sensus_bridge::VisionFilter> for *mut wire_cst_vision_filter {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> crate::api::sensus_bridge::VisionFilter {
@@ -894,9 +1271,72 @@ mod io {
             CstDecode::<crate::api::sensus_bridge::VisionFilter>::cst_decode(*wrap).into()
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::Experience> for wire_cst_experience {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::Experience {
+            crate::api::sensus_bridge::Experience {
+                id: self.id.cst_decode(),
+                vision: self.vision.cst_decode(),
+                hearing: self.hearing.cst_decode(),
+                urgency: self.urgency.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::sensus_bridge::HearingFilter> for wire_cst_hearing_filter {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::HearingFilter {
+            match self.tag {
+                0 => crate::api::sensus_bridge::HearingFilter::HearingLoss,
+                1 => {
+                    let ans = unsafe { self.kind.SuddenHearingLoss };
+                    crate::api::sensus_bridge::HearingFilter::SuddenHearingLoss {
+                        freq_hz: ans.freq_hz.cst_decode(),
+                    }
+                }
+                2 => crate::api::sensus_bridge::HearingFilter::NoiseInducedHearingLoss,
+                3 => {
+                    let ans = unsafe { self.kind.Tinnitus };
+                    crate::api::sensus_bridge::HearingFilter::Tinnitus {
+                        freq_hz: ans.freq_hz.cst_decode(),
+                    }
+                }
+                4 => crate::api::sensus_bridge::HearingFilter::Hyperacusis,
+                5 => {
+                    let ans = unsafe { self.kind.Misophonia };
+                    crate::api::sensus_bridge::HearingFilter::Misophonia {
+                        freq_hz: ans.freq_hz.cst_decode(),
+                    }
+                }
+                6 => crate::api::sensus_bridge::HearingFilter::Paracusis,
+                7 => crate::api::sensus_bridge::HearingFilter::Amusia,
+                8 => crate::api::sensus_bridge::HearingFilter::Dysmelodia,
+                9 => {
+                    let ans = unsafe { self.kind.PitchShift };
+                    crate::api::sensus_bridge::HearingFilter::PitchShift {
+                        semitones: ans.semitones.cst_decode(),
+                    }
+                }
+                10 => crate::api::sensus_bridge::HearingFilter::Diplacusis,
+                11 => crate::api::sensus_bridge::HearingFilter::AuditoryProcessingDisorder,
+                12 => crate::api::sensus_bridge::HearingFilter::Meniere,
+                13 => crate::api::sensus_bridge::HearingFilter::Labyrinthitis,
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<Vec<String>> for *mut wire_cst_list_String {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<String> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
+    impl CstDecode<Vec<crate::api::sensus_bridge::Experience>> for *mut wire_cst_list_experience {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::sensus_bridge::Experience> {
             let vec = unsafe {
                 let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
                 flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
@@ -1035,6 +1475,34 @@ mod io {
             }
         }
     }
+    impl NewWithNullPtr for wire_cst_experience {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                id: core::ptr::null_mut(),
+                vision: core::ptr::null_mut(),
+                hearing: core::ptr::null_mut(),
+                urgency: Default::default(),
+            }
+        }
+    }
+    impl Default for wire_cst_experience {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_hearing_filter {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: HearingFilterKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_hearing_filter {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
     impl NewWithNullPtr for wire_cst_vision_filter {
         fn new_with_null_ptr() -> Self {
             Self {
@@ -1063,6 +1531,12 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__experiences(
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__sensus_bridge__experiences_impl()
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_wire__crate__api__sensus_bridge__vision_shader_glsl(
         filter: *mut wire_cst_vision_filter,
     ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
@@ -1088,6 +1562,14 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_universal_experience_cst_new_box_autoadd_hearing_filter(
+    ) -> *mut wire_cst_hearing_filter {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_hearing_filter::new_with_null_ptr(),
+        )
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_universal_experience_cst_new_box_autoadd_vision_filter(
     ) -> *mut wire_cst_vision_filter {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(
@@ -1102,6 +1584,20 @@ mod io {
         let wrap = wire_cst_list_String {
             ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
                 <*mut wire_cst_list_prim_u_8_strict>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_universal_experience_cst_new_list_experience(
+        len: i32,
+    ) -> *mut wire_cst_list_experience {
+        let wrap = wire_cst_list_experience {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_experience>::new_with_null_ptr(),
                 len,
             ),
             len,
@@ -1144,8 +1640,57 @@ mod io {
 
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_experience {
+        id: *mut wire_cst_list_prim_u_8_strict,
+        vision: *mut wire_cst_vision_filter,
+        hearing: *mut wire_cst_hearing_filter,
+        urgency: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_hearing_filter {
+        tag: i32,
+        kind: HearingFilterKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union HearingFilterKind {
+        SuddenHearingLoss: wire_cst_HearingFilter_SuddenHearingLoss,
+        Tinnitus: wire_cst_HearingFilter_Tinnitus,
+        Misophonia: wire_cst_HearingFilter_Misophonia,
+        PitchShift: wire_cst_HearingFilter_PitchShift,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_HearingFilter_SuddenHearingLoss {
+        freq_hz: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_HearingFilter_Tinnitus {
+        freq_hz: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_HearingFilter_Misophonia {
+        freq_hz: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_HearingFilter_PitchShift {
+        semitones: f32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_list_String {
         ptr: *mut *mut wire_cst_list_prim_u_8_strict,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_experience {
+        ptr: *mut wire_cst_experience,
         len: i32,
     }
     #[repr(C)]
@@ -1287,9 +1832,76 @@ mod web {
             self
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::Experience>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::Experience {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                4,
+                "Expected 4 elements, got {}",
+                self_.length()
+            );
+            crate::api::sensus_bridge::Experience {
+                id: self_.get(0).cst_decode(),
+                vision: self_.get(1).cst_decode(),
+                hearing: self_.get(2).cst_decode(),
+                urgency: self_.get(3).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::sensus_bridge::HearingFilter>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::HearingFilter {
+            let self_ = self.unchecked_into::<flutter_rust_bridge::for_generated::js_sys::Array>();
+            match self_.get(0).unchecked_into_f64() as _ {
+                0 => crate::api::sensus_bridge::HearingFilter::HearingLoss,
+                1 => crate::api::sensus_bridge::HearingFilter::SuddenHearingLoss {
+                    freq_hz: self_.get(1).cst_decode(),
+                },
+                2 => crate::api::sensus_bridge::HearingFilter::NoiseInducedHearingLoss,
+                3 => crate::api::sensus_bridge::HearingFilter::Tinnitus {
+                    freq_hz: self_.get(1).cst_decode(),
+                },
+                4 => crate::api::sensus_bridge::HearingFilter::Hyperacusis,
+                5 => crate::api::sensus_bridge::HearingFilter::Misophonia {
+                    freq_hz: self_.get(1).cst_decode(),
+                },
+                6 => crate::api::sensus_bridge::HearingFilter::Paracusis,
+                7 => crate::api::sensus_bridge::HearingFilter::Amusia,
+                8 => crate::api::sensus_bridge::HearingFilter::Dysmelodia,
+                9 => crate::api::sensus_bridge::HearingFilter::PitchShift {
+                    semitones: self_.get(1).cst_decode(),
+                },
+                10 => crate::api::sensus_bridge::HearingFilter::Diplacusis,
+                11 => crate::api::sensus_bridge::HearingFilter::AuditoryProcessingDisorder,
+                12 => crate::api::sensus_bridge::HearingFilter::Meniere,
+                13 => crate::api::sensus_bridge::HearingFilter::Labyrinthitis,
+                _ => unreachable!(),
+            }
+        }
+    }
     impl CstDecode<Vec<String>> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Vec<String> {
+            self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap()
+                .iter()
+                .map(CstDecode::cst_decode)
+                .collect()
+        }
+    }
+    impl CstDecode<Vec<crate::api::sensus_bridge::Experience>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::sensus_bridge::Experience> {
             self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
                 .unwrap()
                 .iter()
@@ -1435,6 +2047,14 @@ mod web {
             self.unchecked_into_f64() as _
         }
     }
+    impl CstDecode<crate::api::sensus_bridge::Urgency>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::sensus_bridge::Urgency {
+            (self.unchecked_into_f64() as i32).cst_decode()
+        }
+    }
     impl CstDecode<crate::api::sensus_bridge::VisionGlaucomaMode>
         for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
     {
@@ -1455,6 +2075,12 @@ mod web {
         wire__crate__api__sensus_bridge__apply_vision_cpu_rgba8_impl(
             filter, rgba8, width, height, strength,
         )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__sensus_bridge__experiences(
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__sensus_bridge__experiences_impl()
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
## 関連 Issue
Refs #10（部分。**#10 は open のまま**）

## 達成範囲 / 非スコープ
- **達成**: sensus-core 0.5 の `Experience`（4プリセット）・`Urgency`・`HearingFilter`(14種) の**型を FRB で Dart に公開**。`experiences()` で 4 体験を取得可能に。これは **#19（体験プリセット UI）のブロッカー解消**。
- **非スコープ（#10 に残す）**: HearingFilter の**音声再生**（`apply_hearing` ブリッジ・聴覚モード設計）。聴覚再生は別途（#19 の hearing 注記/聴覚設計に委ねる）。

## 設計（既存ミラー作法に準拠）
外部 crate の型は FRB で直接出せないため ue 側にミラー型を定義（既存 `VisionFilter`/`VisionGlaucomaMode` が手本）。**アルゴリズム・文言は持たせず sensus 正本をミラー＋変換するだけ**（文言は ue i18n #18 が所有）。
- `Urgency`（None/EarlyConsultation/Emergency）+ `from_sensus`
- `HearingFilter`（14 variant・payload 保持）+ `from_sensus`
- `Experience { id, vision: Option<VisionFilter>, hearing: Option<HearingFilter>, urgency }` + `from_sensus`
- `VisionFilter::from_sensus`（既存 `to_sensus` の逆写像・全30 variant 網羅）/ `VisionGlaucomaMode::from_sensus`
- `experiences() -> Vec<Experience>`（`frb(sync)`、MENIERE/BPPV/VESTIBULAR_NEURITIS/LABYRINTHITIS を順序固定で返す）

## 生成物
`flutter_rust_bridge_codegen generate`（v2.11.1）で `lib/src/rust/*`・`rust/src/frb_generated.rs` を再生成（tracked＝コミット）。差分 7 files +4790/-4（大半は freezed の sealed class 生成）。既存 public API の削除なし。

## 検証
- `cargo build` クリーン・`cargo test` **29 passed**（+9: experiences() マッピング・Urgency/HearingFilter/VisionFilter 写像の往復一致）。
- `flutter analyze` **No issues**・`flutter test` **179 passed**（ベースライン維持）。
- Dart 側に `experiences()`/`class Experience`/`sealed class HearingFilter`/`enum Urgency` 生成を確認。
- 注: 型公開のみで描画挙動は不変。実機 A-B 目視サインオフは #19 の UI と合わせて。