### PR TITLE
feat: 体験プリセット集 UI（experiences() 消費・受診喚起注記） (#19)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -159,6 +159,51 @@
     "description": "Prompt to seek timely care for high-urgency conditions. Must be accurate and not alarmist."
   },
 
+  "experienceSectionTitle": "Experience Presets",
+  "@experienceSectionTitle": {
+    "description": "Title of the experience-presets section that lists composite vestibular experiences from the sensus bridge."
+  },
+  "experienceSectionNote": "Curated composite experiences from sensus. Tap one to apply its vision filter. Some include hearing symptoms (audio playback is not yet supported).",
+  "@experienceSectionNote": {
+    "description": "Explanatory note under the experience-presets section. Must not over-promise; audio is out of scope here."
+  },
+  "experienceMeniere": "Ménière's disease",
+  "@experienceMeniere": {
+    "description": "Name of the Ménière's disease experience preset."
+  },
+  "experienceMeniereDesc": "Recurrent vertigo with low-tone hearing loss, ear fullness, and a low roaring tinnitus.",
+  "@experienceMeniereDesc": {
+    "description": "Short triad description of Ménière's disease. Accurate, non-alarmist."
+  },
+  "experienceBppv": "Benign paroxysmal positional vertigo",
+  "@experienceBppv": {
+    "description": "Name of the BPPV experience preset."
+  },
+  "experienceBppvDesc": "Brief spinning vertigo triggered by head-position changes, with no hearing symptoms.",
+  "@experienceBppvDesc": {
+    "description": "Short description of BPPV. Accurate, non-alarmist."
+  },
+  "experienceVestibularNeuritis": "Vestibular neuritis",
+  "@experienceVestibularNeuritis": {
+    "description": "Name of the vestibular neuritis experience preset."
+  },
+  "experienceVestibularNeuritisDesc": "Sudden, intense, continuous vertigo from vestibular nerve inflammation, with hearing preserved.",
+  "@experienceVestibularNeuritisDesc": {
+    "description": "Short description of vestibular neuritis. Accurate, non-alarmist."
+  },
+  "experienceLabyrinthitis": "Labyrinthitis",
+  "@experienceLabyrinthitis": {
+    "description": "Name of the labyrinthitis experience preset."
+  },
+  "experienceLabyrinthitisDesc": "Vertigo combined with high-tone hearing loss and a high-pitched tinnitus from inner-ear inflammation.",
+  "@experienceLabyrinthitisDesc": {
+    "description": "Short triad description of labyrinthitis. Accurate, non-alarmist."
+  },
+  "experienceIncludesHearingNote": "This experience also includes hearing symptoms (audio playback is not yet supported).",
+  "@experienceIncludesHearingNote": {
+    "description": "Note shown for experiences whose composite includes a hearing filter. Audio is out of scope for #19; only the vision filter is applied."
+  },
+
   "trayTooltip": "Universal Experience",
   "@trayTooltip": {
     "description": "Tray icon tooltip."

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -45,6 +45,18 @@
   "consultEarly": "もしこのような見え方をしているなら、一度眼科で診てもらうとよいかもしれません。",
   "consultEmergency": "見え方が急に変わったときは、早めに医療機関を受診してください。",
 
+  "experienceSectionTitle": "体験プリセット",
+  "experienceSectionNote": "sensus が用意した複合的な体験です。タップするとその視覚フィルタが適用されます。聴覚症状を含むものもあります（音声再生は未対応です）。",
+  "experienceMeniere": "メニエール病",
+  "experienceMeniereDesc": "回転性めまいを繰り返し、低音域の難聴・耳のつまり感・低い唸るような耳鳴りを伴います。",
+  "experienceBppv": "良性発作性頭位めまい症",
+  "experienceBppvDesc": "頭の位置を変えたときに起こる、短時間の回転性めまいです。聴覚症状はありません。",
+  "experienceVestibularNeuritis": "前庭神経炎",
+  "experienceVestibularNeuritisDesc": "前庭神経の炎症によって突然起こる、強く持続する回転性めまいです。聴力は保たれます。",
+  "experienceLabyrinthitis": "迷路炎",
+  "experienceLabyrinthitisDesc": "内耳の炎症により、回転性めまいに加えて高音域の難聴と高い耳鳴りを伴います。",
+  "experienceIncludesHearingNote": "この体験には聴覚症状も含まれます（音声再生は未対応です）。",
+
   "trayTooltip": "Universal Experience",
   "trayShowLoupe": "ルーペ窓を表示",
   "trayHideLoupe": "ルーペ窓を隠す",

--- a/lib/l10n/l10n_extensions.dart
+++ b/lib/l10n/l10n_extensions.dart
@@ -1,6 +1,7 @@
 import '../models/disability_type.dart';
 import '../models/vision_filter_catalog.dart';
 import '../services/tray_service.dart';
+import '../src/rust/api/sensus_bridge.dart';
 import 'app_localizations.dart';
 
 /// 定義（enum / catalog id）→ 表示文言（i18n）の解決をここに集約する (#18)。
@@ -267,6 +268,61 @@ String visionParamLabel(AppLocalizations l10n, String labelKey) {
       return l10n.paramFlickeringStarsSeed;
     default:
       return labelKey;
+  }
+}
+
+/// 体験プリセット (#19) の id（sensus `Experience.id`）→ 表示名を解決する。
+///
+/// id は sensus が返す安定識別子（`meniere` / `bppv` / `vestibular_neuritis` /
+/// `labyrinthitis`）。表示名・説明は文言を持たず、ここで i18n に写像する（規律2）。
+String experienceName(AppLocalizations l10n, String id) {
+  switch (id) {
+    case 'meniere':
+      return l10n.experienceMeniere;
+    case 'bppv':
+      return l10n.experienceBppv;
+    case 'vestibular_neuritis':
+      return l10n.experienceVestibularNeuritis;
+    case 'labyrinthitis':
+      return l10n.experienceLabyrinthitis;
+    default:
+      return id;
+  }
+}
+
+/// 体験プリセット (#19) の id → 三徴候の簡潔な説明を解決する。
+String experienceDescription(AppLocalizations l10n, String id) {
+  switch (id) {
+    case 'meniere':
+      return l10n.experienceMeniereDesc;
+    case 'bppv':
+      return l10n.experienceBppvDesc;
+    case 'vestibular_neuritis':
+      return l10n.experienceVestibularNeuritisDesc;
+    case 'labyrinthitis':
+      return l10n.experienceLabyrinthitisDesc;
+    default:
+      return id;
+  }
+}
+
+/// 体験プリセットの [Urgency]（sensus 由来）→ 受診喚起メッセージを解決する。
+///
+/// null = 喚起なし。`Urgency` の分類は bridge（sensus）が持ち、当事者への注記文言は
+/// ue 側が i18n で所有する（規律2）。`earlyConsultation` = 早期受診を促す穏やかな
+/// 注記、`emergency` = 速やかな受診を促す注記。`none` では出さない。
+///
+/// NOTE: catalog 側 [VisionFilterUrgency] 用の [consultMessageForUrgency] とは別系統
+/// （#19 体験プリセットは bridge の `Urgency` 3 値を使う）。文言キー
+/// `consultEarly` / `consultEmergency` は両者で共有する。
+String? urgencyConsultMessage(AppLocalizations l10n, Urgency urgency) {
+  switch (urgency) {
+    case Urgency.none:
+      return null;
+    case Urgency.earlyConsultation:
+      return l10n.consultEarly;
+    case Urgency.emergency:
+      return l10n.consultEmergency;
   }
 }
 

--- a/lib/models/vision_filter_catalog.dart
+++ b/lib/models/vision_filter_catalog.dart
@@ -708,3 +708,41 @@ List<VisionFilterEntry> visionFilterEntriesByCategory(
   VisionFilterCategory category,
 ) =>
     kVisionFilterCatalog.where((e) => e.category == category).toList();
+
+/// payload を持たない（const 構築できる）[VisionFilter] → カタログ id の写像。
+///
+/// 体験プリセット (#19) の `Experience.vision`（bridge の [VisionFilter] インスタンス）
+/// を、カタログの snake_case id（[VisionFilterState.select] が受ける値）へ変換する
+/// ための単一の正本。**id をハードコード散在させない**ため、ここ 1 箇所に集約する。
+///
+/// freezed の値等価（payload 無しバリアントは同値）を使って引く。payload を持つ
+/// フィルタ（astigmatism 等）は const 構築できず体験プリセットでも使われないため
+/// 対象外（[visionFilterCatalogId] が null を返す）。
+final Map<VisionFilter, String> _kCatalogIdByParamlessVision = {
+  const VisionFilter.protanopia(): 'protanopia',
+  const VisionFilter.deuteranopia(): 'deuteranopia',
+  const VisionFilter.tritanopia(): 'tritanopia',
+  const VisionFilter.achromatopsia(): 'achromatopsia',
+  const VisionFilter.tetrachromacy(): 'tetrachromacy',
+  const VisionFilter.myopia(): 'myopia',
+  const VisionFilter.hyperopia(): 'hyperopia',
+  const VisionFilter.presbyopia(): 'presbyopia',
+  const VisionFilter.macularDegeneration(): 'macular_degeneration',
+  const VisionFilter.tunnelVision(): 'tunnel_vision',
+  const VisionFilter.photophobia(): 'photophobia',
+  const VisionFilter.nightBlindness(): 'night_blindness',
+  const VisionFilter.vertigo(): 'vertigo',
+  const VisionFilter.bppvRotation(): 'bppv_rotation',
+  const VisionFilter.vestibularNeuritis(): 'vestibular_neuritis',
+  const VisionFilter.eyeStrain(): 'eye_strain',
+  const VisionFilter.dryEye(): 'dry_eye',
+  const VisionFilter.contrastSensitivity(): 'contrast_sensitivity',
+  const VisionFilter.teichopsia(): 'teichopsia',
+};
+
+/// [VisionFilter] インスタンス → カタログ id（snake_case）を引く。未知なら null。
+///
+/// 体験プリセット (#19) が `Experience.vision` を [VisionFilterState.select] へ橋渡し
+/// するのに使う。payload を持つフィルタ（体験プリセットでは未使用）は null を返す。
+String? visionFilterCatalogId(VisionFilter filter) =>
+    _kCatalogIdByParamlessVision[filter];

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../../models/disability_type.dart';
 import '../../services/filter_service.dart';
 import '../../services/settings_service.dart';
 import '../widgets/before_after_view.dart';
+import '../widgets/experience_presets.dart';
 import '../widgets/filter_selector.dart';
 import '../widgets/intensity_slider.dart';
 import '../widgets/filter_catalog_selector.dart';
@@ -78,6 +79,8 @@ class _HomeScreenState extends State<HomeScreen> {
               _buildPreviewSection(),
               const SizedBox(height: 32),
               _buildAdvancedSection(l10n),
+              const SizedBox(height: 32),
+              _buildExperiencePresetsSection(l10n),
               const SizedBox(height: 32),
               _buildInfoSection(),
             ],
@@ -259,6 +262,48 @@ class _HomeScreenState extends State<HomeScreen> {
             const FilterCatalogSelector(),
             const Divider(height: 32),
             const FilterParamPanel(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 体験プリセット集 (#19) セクション。sensus の experiences() を消費し、
+  /// 複合体験（前庭性めまい系 4 種）をタップで視覚フィルタに適用する。聴覚再生は
+  /// 本 Issue 非スコープで、聴覚を含む体験は注記に留める。
+  Widget _buildExperiencePresetsSection(AppLocalizations l10n) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.auto_awesome, color: Colors.indigo.shade600),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    l10n.experienceSectionTitle,
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.experienceSectionNote,
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.grey.shade600,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            const SizedBox(height: 20),
+            const ExperiencePresets(),
           ],
         ),
       ),

--- a/lib/ui/widgets/experience_presets.dart
+++ b/lib/ui/widgets/experience_presets.dart
@@ -16,6 +16,10 @@ import '../../src/rust/api/sensus_bridge.dart';
 typedef ExperiencesProvider = List<Experience> Function();
 
 /// 体験プリセット供給源（テストで差し替え可能）。既定は bridge の [experiences]。
+///
+/// production からは既定値（実 bridge）をそのまま使う。差し替えは widget test の
+/// fixture 注入専用なので、外部からの書き換えを抑止するため `@visibleForTesting`。
+@visibleForTesting
 ExperiencesProvider experiencesProvider = experiences;
 
 /// 体験プリセット集 (#19)。

--- a/lib/ui/widgets/experience_presets.dart
+++ b/lib/ui/widgets/experience_presets.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../l10n/l10n_extensions.dart';
+import '../../models/vision_filter_catalog.dart';
+import '../../services/filter_service.dart';
+import '../../services/vision_filter_state.dart';
+import '../../src/rust/api/sensus_bridge.dart';
+
+/// 体験プリセットの供給源。既定は sensus bridge の [experiences]。
+///
+/// FRB の `experiences()` は native lib を要求し `flutter test`（FFI 未ロード）では
+/// 呼べないため、widget test はこの seam を fixture で差し替えて検証する。production
+/// では bridge の `experiences()` をそのまま消費する（sensus を再実装しない）。
+typedef ExperiencesProvider = List<Experience> Function();
+
+/// 体験プリセット供給源（テストで差し替え可能）。既定は bridge の [experiences]。
+ExperiencesProvider experiencesProvider = experiences;
+
+/// 体験プリセット集 (#19)。
+///
+/// sensus の [experiences]（meniere / bppv / vestibular_neuritis / labyrinthitis の
+/// 4 体験）を消費し、各体験をタップで「視覚フィルタの選択」に橋渡しする。
+///
+/// - 視覚: `Experience.vision`（bridge の [VisionFilter]）を [visionFilterCatalogId]
+///   でカタログ id（snake_case）へ写し、[VisionFilterState.select] に渡す。id を
+///   ハードコードせずカタログを正本に引く。
+/// - 受診喚起: `Experience.urgency`（bridge の [Urgency]）を [urgencyConsultMessage]
+///   で i18n 注記へ写す。`none` では出さない。
+/// - 聴覚: hearing を含む体験（meniere / labyrinthitis）は「聴覚症状も含む」注記に
+///   留める。**音声再生は本 Issue 非スコープ**（聴覚モード設計に委ねる）。音は鳴らさない。
+///
+/// 文言は持たず、id / 分類から i18n で解決する（規律2）。
+class ExperiencePresets extends StatelessWidget {
+  const ExperiencePresets({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final presets = experiencesProvider();
+    return Consumer<VisionFilterState>(
+      builder: (context, state, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final exp in presets)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: _ExperienceCard(experience: exp, state: state),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ExperienceCard extends StatelessWidget {
+  const _ExperienceCard({required this.experience, required this.state});
+
+  final Experience experience;
+  final VisionFilterState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    final catalogId = experience.vision == null
+        ? null
+        : visionFilterCatalogId(experience.vision!);
+    final isSelected = catalogId != null && state.selectedId == catalogId;
+    final consult = urgencyConsultMessage(l10n, experience.urgency);
+    final includesHearing = experience.hearing != null;
+
+    return Card(
+      // 選択中のプリセットを縁取りで示す。
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: isSelected
+            ? BorderSide(color: theme.colorScheme.primary, width: 2)
+            : BorderSide(color: theme.dividerColor),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        // 視覚フィルタを持つ体験のみ適用可能（4 体験はすべて vision を持つ）。
+        onTap: catalogId == null ? null : () => _apply(context, catalogId),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      experienceName(l10n, experience.id),
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  if (isSelected)
+                    Icon(Icons.check_circle, color: theme.colorScheme.primary),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                experienceDescription(l10n, experience.id),
+                style: theme.textTheme.bodyMedium,
+              ),
+              if (includesHearing) ...[
+                const SizedBox(height: 8),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.hearing,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        l10n.experienceIncludesHearingNote,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontStyle: FontStyle.italic,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+              if (consult != null) ...[
+                const SizedBox(height: 8),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      experience.urgency == Urgency.emergency
+                          ? Icons.warning_amber_rounded
+                          : Icons.info_outline,
+                      size: 16,
+                      color: experience.urgency == Urgency.emergency
+                          ? theme.colorScheme.error
+                          : theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        consult,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: experience.urgency == Urgency.emergency
+                              ? theme.colorScheme.error
+                              : theme.colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 体験を適用する: 視覚フィルタを選択状態にする。
+  ///
+  /// 体験は advanced 系（[VisionFilterState]）で適用するため、色覚系
+  /// （[FilterService]）は none に戻し、色覚との二重適用を避ける（重ね掛けは #41）。
+  void _apply(BuildContext context, String catalogId) {
+    context.read<VisionFilterState>().select(catalogId);
+    context.read<FilterService>().deactivate();
+  }
+}

--- a/test/experience_presets_test.dart
+++ b/test/experience_presets_test.dart
@@ -1,0 +1,181 @@
+// 体験プリセット集 (#19) の widget test。
+//
+// 検証:
+// 1. 4 プリセットが i18n 名で描画される。
+// 2. タップで VisionFilterState.selectedId が対応 catalog id になる
+//    （meniere→vertigo / bppv→bppv_rotation）。色覚 FilterService は none に戻る。
+// 3. urgency=emergency（vestibular_neuritis）で緊急受診、earlyConsultation（meniere）
+//    で早期受診メッセージ、none（bppv）では受診喚起が出ない。
+// 4. hearing を含む体験（meniere/labyrinthitis）で「聴覚も含む」注記が出る。
+//
+// bridge の experiences() は native lib（FFI）を要求し flutter test では呼べないため、
+// experiencesProvider seam を fixture で差し替える（音声再生は #19 非スコープ）。
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:universal_experience/l10n/app_localizations.dart';
+import 'package:universal_experience/models/disability_type.dart';
+import 'package:universal_experience/services/filter_service.dart';
+import 'package:universal_experience/services/vision_filter_state.dart';
+import 'package:universal_experience/src/rust/api/sensus_bridge.dart';
+import 'package:universal_experience/ui/widgets/experience_presets.dart';
+
+/// テスト用の 4 体験 fixture（sensus の experiences() と同じ id / vision / hearing /
+/// urgency）。実 bridge は native を要求するため fixture で代替する。
+List<Experience> _fixtureExperiences() => const [
+      Experience(
+        id: 'meniere',
+        vision: VisionFilter.vertigo(),
+        hearing: HearingFilter.meniere(),
+        urgency: Urgency.earlyConsultation,
+      ),
+      Experience(
+        id: 'bppv',
+        vision: VisionFilter.bppvRotation(),
+        urgency: Urgency.none,
+      ),
+      Experience(
+        id: 'vestibular_neuritis',
+        vision: VisionFilter.vestibularNeuritis(),
+        urgency: Urgency.emergency,
+      ),
+      Experience(
+        id: 'labyrinthitis',
+        vision: VisionFilter.vertigo(),
+        hearing: HearingFilter.labyrinthitis(),
+        urgency: Urgency.earlyConsultation,
+      ),
+    ];
+
+void main() {
+  late VisionFilterState visionState;
+  late FilterService filterService;
+
+  setUp(() {
+    experiencesProvider = _fixtureExperiences;
+    visionState = VisionFilterState();
+    filterService = FilterService();
+  });
+  tearDown(() => experiencesProvider = experiences);
+
+  Future<void> pumpPresets(WidgetTester tester, Locale locale) async {
+    // ListView 内の全カードが lazy build されるよう十分高いビューポートにする。
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<VisionFilterState>.value(value: visionState),
+          ChangeNotifierProvider<FilterService>.value(value: filterService),
+        ],
+        child: MaterialApp(
+          locale: locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(
+            body: SingleChildScrollView(child: ExperiencePresets()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('4 プリセットが i18n 名で描画される', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(en.experienceMeniere), findsOneWidget);
+    expect(find.text(en.experienceBppv), findsOneWidget);
+    expect(find.text(en.experienceVestibularNeuritis), findsOneWidget);
+    expect(find.text(en.experienceLabyrinthitis), findsOneWidget);
+  });
+
+  testWidgets('ja でも日本語の体験名が出る', (tester) async {
+    await pumpPresets(tester, const Locale('ja'));
+    final ja = lookupAppLocalizations(const Locale('ja'));
+    expect(find.text(ja.experienceMeniere), findsOneWidget); // メニエール病
+    expect(find.text(ja.experienceVestibularNeuritis), findsOneWidget); // 前庭神経炎
+  });
+
+  testWidgets('meniere タップで vision=vertigo を選択し色覚は none に戻る', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+
+    // 事前に色覚フィルタを有効化しておき、適用で解除されることを確認する。
+    filterService.applyFilter(ColorVisionType.protanopia);
+    expect(filterService.currentFilter, ColorVisionType.protanopia);
+
+    await tester.tap(find.text(en.experienceMeniere));
+    await tester.pump();
+
+    expect(visionState.selectedId, 'vertigo');
+    expect(filterService.currentFilter, ColorVisionType.none);
+  });
+
+  testWidgets('bppv タップで vision=bppv_rotation を選択する', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+
+    await tester.tap(find.text(en.experienceBppv));
+    await tester.pump();
+
+    expect(visionState.selectedId, 'bppv_rotation');
+  });
+
+  testWidgets('vestibular_neuritis は緊急受診メッセージを出す', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(en.consultEmergency), findsOneWidget);
+  });
+
+  testWidgets('meniere は早期受診メッセージを出す', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    // meniere / labyrinthitis の 2 体験が earlyConsultation。
+    expect(find.text(en.consultEarly), findsNWidgets(2));
+  });
+
+  testWidgets('bppv（urgency none）は受診喚起を出さない', (tester) async {
+    // bppv だけを供給し、受診喚起が一切出ないことを確認する。
+    experiencesProvider = () => const [
+          Experience(
+            id: 'bppv',
+            vision: VisionFilter.bppvRotation(),
+            urgency: Urgency.none,
+          ),
+        ];
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(en.consultEarly), findsNothing);
+    expect(find.text(en.consultEmergency), findsNothing);
+  });
+
+  testWidgets('聴覚を含む体験（meniere/labyrinthitis）で聴覚注記が出る', (tester) async {
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    // meniere と labyrinthitis の 2 体験が hearing を持つ → 注記 2 件。
+    expect(find.text(en.experienceIncludesHearingNote), findsNWidgets(2));
+  });
+
+  testWidgets('聴覚を含まない体験（bppv 単独）では聴覚注記が出ない', (tester) async {
+    experiencesProvider = () => const [
+          Experience(
+            id: 'bppv',
+            vision: VisionFilter.bppvRotation(),
+            urgency: Urgency.none,
+          ),
+        ];
+    await pumpPresets(tester, const Locale('en'));
+    final en = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(en.experienceIncludesHearingNote), findsNothing);
+  });
+}

--- a/test/i18n_test.dart
+++ b/test/i18n_test.dart
@@ -227,9 +227,9 @@ void main() {
       state.select('glaucoma');
       await tester.pump();
 
-      // glaucoma 選択で param panel に緊急受診メッセージが出る。加えて体験プリセット
-      // 集 (#19) の vestibular_neuritis（emergency）も常時同じメッセージを表示するため
-      // 計 2 件になる。少なくとも param panel 分が出ていることを保証する。
+      // glaucoma 選択で param panel に緊急受診メッセージが 1 件。加えて体験プリセット
+      // 集 (#19) の vestibular_neuritis（emergency）が常時同じメッセージを表示するため
+      // 厳密に計 2 件。プリセットが落ちたら 1 件になり検出できる（exact count）。
       expect(find.text(en.consultEmergency), findsNWidgets(2));
     });
   });

--- a/test/i18n_test.dart
+++ b/test/i18n_test.dart
@@ -21,7 +21,9 @@ import 'package:universal_experience/models/vision_filter_catalog.dart';
 import 'package:universal_experience/services/filter_service.dart';
 import 'package:universal_experience/services/settings_service.dart';
 import 'package:universal_experience/services/vision_filter_state.dart';
+import 'package:universal_experience/src/rust/api/sensus_bridge.dart';
 import 'package:universal_experience/ui/screens/home_screen.dart';
+import 'package:universal_experience/ui/widgets/experience_presets.dart';
 
 Map<String, dynamic> _readArb(String name) {
   final file = File('lib/l10n/$name');
@@ -129,6 +131,36 @@ void main() {
   });
 
   group('HomeScreen ロケール別描画', () {
+    // HomeScreen は体験プリセット集 (#19) が bridge の experiences() を呼ぶ。FFI 未
+    // ロードの flutter test では native を叩けないため、fixture で seam を差し替える。
+    setUp(() {
+      experiencesProvider = () => const [
+            Experience(
+              id: 'meniere',
+              vision: VisionFilter.vertigo(),
+              hearing: HearingFilter.meniere(),
+              urgency: Urgency.earlyConsultation,
+            ),
+            Experience(
+              id: 'bppv',
+              vision: VisionFilter.bppvRotation(),
+              urgency: Urgency.none,
+            ),
+            Experience(
+              id: 'vestibular_neuritis',
+              vision: VisionFilter.vestibularNeuritis(),
+              urgency: Urgency.emergency,
+            ),
+            Experience(
+              id: 'labyrinthitis',
+              vision: VisionFilter.vertigo(),
+              hearing: HearingFilter.labyrinthitis(),
+              urgency: Urgency.earlyConsultation,
+            ),
+          ];
+    });
+    tearDown(() => experiencesProvider = experiences);
+
     Future<void> pumpHome(WidgetTester tester, Locale locale) async {
       // HomeScreen は ListView で縦に長いため、全セクションが lazy build されるよう
       // 十分に高いビューポートにする（小さいと下のセクションが未生成で見つからない）。
@@ -195,7 +227,10 @@ void main() {
       state.select('glaucoma');
       await tester.pump();
 
-      expect(find.text(en.consultEmergency), findsOneWidget);
+      // glaucoma 選択で param panel に緊急受診メッセージが出る。加えて体験プリセット
+      // 集 (#19) の vestibular_neuritis（emergency）も常時同じメッセージを表示するため
+      // 計 2 件になる。少なくとも param panel 分が出ていることを保証する。
+      expect(find.text(en.consultEmergency), findsNWidgets(2));
     });
   });
 }


### PR DESCRIPTION
## 関連 Issue
closes #19

## 概要
#10 で公開した `experiences()` ブリッジを消費し、sensus の4複合体験（メニエール病/BPPV/前庭神経炎/迷路炎）を「体験プリセット」として並べ、ワンタップで vision フィルタを適用＋受診喚起を表示する UI。**sensus 正本を再実装せず experiences() をそのまま消費**（規律2/3）。

## 変更
- **`lib/ui/widgets/experience_presets.dart`**: `ExperiencePresets` + カード。各体験の名称・三徴候説明・（聴覚を含む体験は）聴覚注記・（urgency があれば）受診喚起を表示し、タップで適用。`home_screen.dart` に advanced 直後・info 前へセクション挿入。
- **vision 適用**: `vision_filter_catalog.dart` に `visionFilterCatalogId(VisionFilter)`（payload なし全 VisionFilter→snake_case id の単一マップ正本）を新設。タップで `VisionFilterState.select(id)`（例 meniere→`vertigo`、bppv→`bppv_rotation`）。同時に `FilterService.deactivate()` で色覚を none に戻し二重適用を回避（重ね掛け #41 とは分離）。
- **i18n（#18 基盤・en/ja parity 139=139）**: 体験名/説明/セクション/聴覚注記キーを追加。`l10n_extensions.dart` に `experienceName`/`experienceDescription`/`urgencyConsultMessage(Urgency)` リゾルバ（enum/id に文言を持たせない）。受診喚起は #18 の `consultEarly`/`consultEmergency` を Urgency 写像で再利用。

## 非スコープ（明記）
- **聴覚再生**: 本 Issue 非スコープ。聴覚を含む体験は「聴覚症状も含む（音声再生未対応）」の注記のみ＝聴覚モード設計に委ねる（#10 の音声再生残・聴覚設計）。
- vestibular フィルタの **live 描画**は #1/#2 で未実装（preview は coming soon になりうる）。本 PR は選択状態の配線まで。

## テスト
- `test/experience_presets_test.dart`（9件）: 4プリセット描画（en/ja）/ タップで正しい catalog id 選択＋色覚 none 復帰 / urgency 写像（emergency=vestibular_neuritis・earlyConsultation=meniere/labyrinthitis・none=bppv は非表示）/ 聴覚注記の出し分け。
- **FFI seam**: `experiences()` は FRB sync で native lib を要し `flutter test` で呼ぶとクラッシュするため、差し替え可能な `experiencesProvider`（既定=実 `experiences`）経由で消費しテストは fixture 注入。production は実ブリッジを使用。
- `flutter analyze` No issues・`flutter test` **188 passed**（179+9）・ARB parity 維持・`dart format` 済み。
- 注: 実機 run でのプリセット並び・適用・注記の目視サインオフは別途。