### PR TITLE
feat: フィルタ済み画像のメタ焼き込み PNG エクスポート (#43)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -159,6 +159,22 @@
     "description": "Prompt to seek timely care for high-urgency conditions. Must be accurate and not alarmist."
   },
 
+  "exportButtonTooltip": "Export as PNG",
+  "@exportButtonTooltip": {
+    "description": "Tooltip for the icon button that exports the filtered 'after' image as a PNG with burned-in metadata (#43)."
+  },
+  "exportSuccess": "Exported to {path}",
+  "@exportSuccess": {
+    "description": "SnackBar shown after a successful PNG export. The file path is also copied to the clipboard.",
+    "placeholders": {
+      "path": { "type": "String" }
+    }
+  },
+  "exportFailure": "Export failed. Please try again.",
+  "@exportFailure": {
+    "description": "SnackBar shown when PNG export fails (no exception detail is leaked to the UI)."
+  },
+
   "experienceSectionTitle": "Experience Presets",
   "@experienceSectionTitle": {
     "description": "Title of the experience-presets section that lists composite vestibular experiences from the sensus bridge."

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -45,6 +45,10 @@
   "consultEarly": "もしこのような見え方をしているなら、一度眼科で診てもらうとよいかもしれません。",
   "consultEmergency": "見え方が急に変わったときは、早めに医療機関を受診してください。",
 
+  "exportButtonTooltip": "PNG でエクスポート",
+  "exportSuccess": "エクスポートしました：{path}",
+  "exportFailure": "エクスポートに失敗しました。もう一度お試しください。",
+
   "experienceSectionTitle": "体験プリセット",
   "experienceSectionNote": "sensus が用意した複合的な体験です。タップするとその視覚フィルタが適用されます。聴覚症状を含むものもあります（音声再生は未対応です）。",
   "experienceMeniere": "メニエール病",

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/painting.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// フィルタ適用後（after）画像を、症状名・強度・受診喚起・日付を焼き込んだ
+/// PNG として書き出すための pure 中核 + I/O 分離サービス (#43)。
+///
+/// 規律2（定義/状態の分離）に従い、このサービスは **enum / i18n を一切引かない**。
+/// 表示文言（症状名・強度ラベル・受診喚起・ISO 日付）は呼び出し側（UI）が
+/// `AppLocalizations` で解決し、[ExportCaption] として渡す。これによりサービスは
+/// pure（テスト容易・ロケール非依存）に保たれる。
+///
+/// 規律3（I/O 隔離）に従い、ファイル書き込みは [savePng] のみに閉じ込め、
+/// 画像合成 [composeExportImage] と文字列生成（[isoDate] / [exportFilename]）は
+/// 副作用を持たない純粋関数とする。
+
+/// [DateTime] を `YYYY-MM-DD`（ゼロ埋め・スラッシュ禁止・ISO 固定）に整形する。
+///
+/// 日付表示規約（ISO 8601・スラッシュ M/D は曖昧で不可）に従う。テスト容易性の
+/// ため `DateTime.now()` ではなく引数の [dt] を使う（決定論的）。
+String isoDate(DateTime dt) {
+  final y = dt.year.toString().padLeft(4, '0');
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}
+
+/// エクスポート PNG のファイル名を決定論的に組み立てる。
+///
+/// 例: `ue-protanopia-100pct-2026-06-23.png`。[symptomId] が `none` などでも妥当な
+/// 名前になり、ファイル名に使えない文字（パス区切り・予約文字）は `-` に正規化する。
+/// pure・決定論的（同じ入力なら常に同じ出力）。
+String exportFilename({
+  required String symptomId,
+  required int strengthPercent,
+  required String isoDate,
+}) {
+  final safeId = _sanitizeForFilename(symptomId);
+  return 'ue-$safeId-${strengthPercent}pct-$isoDate.png';
+}
+
+/// ファイル名に使えない文字を `-` に置換し、連続・前後の `-` を畳む。
+String _sanitizeForFilename(String raw) {
+  // 英数・ハイフン・アンダースコア以外を `-` に。空なら `unknown`。
+  final replaced = raw.replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '-');
+  final collapsed = replaced.replaceAll(RegExp(r'-+'), '-');
+  final trimmed = collapsed.replaceAll(RegExp(r'^-+|-+$'), '');
+  return trimmed.isEmpty ? 'unknown' : trimmed;
+}
+
+/// [composeExportImage] に焼き込むキャプション（**解決済み i18n 文字列**）。
+///
+/// service を pure に保つため、enum/id ではなく既にローカライズされた文字列を受ける。
+/// 文言の解決（`colorVisionTypeName` / `consultMessageForUrgency` / 強度ラベル /
+/// `isoDate`）は呼び出し側（UI）の責務。
+class ExportCaption {
+  const ExportCaption({
+    required this.symptomLabel,
+    required this.strengthLabel,
+    required this.isoDate,
+    this.urgencyMessage,
+  });
+
+  /// 症状の表示名（例「1型2色覚（赤）」/ "Protanopia"）。
+  final String symptomLabel;
+
+  /// 強度の表示文字列（例「強度: 100%」/ "Strength: 100%"）。
+  final String strengthLabel;
+
+  /// 受診喚起メッセージ。null = 喚起なし（色覚特性は緊急性 none のため通常 null）。
+  final String? urgencyMessage;
+
+  /// ISO 日付（`YYYY-MM-DD`）。[isoDate] 関数で整形済みの文字列を渡す。
+  final String isoDate;
+}
+
+/// [base] 画像の下部にキャプション帯を合成した新しい [ui.Image] を返す。
+///
+/// `PictureRecorder` + `Canvas` で base をそのまま描き、下に半透明の帯を敷いて
+/// [TextPainter] で症状名 / 強度 / 受診喚起（あれば）/ ISO 日付を描画する。戻り画像の
+/// 高さは `base.height + 帯の高さ`、幅は `base.width`。
+///
+/// **pure**: 引数の解決済み文字列のみを使い、enum/i18n をここで引かない（規律2）。
+/// I/O を持たない（規律3）。
+Future<ui.Image> composeExportImage(
+    ui.Image base, ExportCaption caption) async {
+  final width = base.width;
+  // 行リストを組む（urgencyMessage は任意）。
+  final lines = <_CaptionLine>[
+    _CaptionLine(caption.symptomLabel, _Style.title),
+    _CaptionLine(caption.strengthLabel, _Style.body),
+    if (caption.urgencyMessage != null)
+      _CaptionLine(caption.urgencyMessage!, _Style.note),
+    _CaptionLine(caption.isoDate, _Style.meta),
+  ];
+
+  const horizontalPadding = 16.0;
+  const verticalPadding = 14.0;
+  const lineGap = 6.0;
+  final maxTextWidth = width - horizontalPadding * 2;
+
+  // 各行の TextPainter を用意し、帯の高さを測る。
+  final painters = <TextPainter>[];
+  double textBlockHeight = 0;
+  for (var i = 0; i < lines.length; i++) {
+    final tp = lines[i].buildPainter(maxTextWidth);
+    painters.add(tp);
+    textBlockHeight += tp.height;
+    if (i != lines.length - 1) textBlockHeight += lineGap;
+  }
+  final bandHeight = (textBlockHeight + verticalPadding * 2).ceilToDouble();
+  final totalHeight = base.height + bandHeight.toInt();
+
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder);
+
+  // base をそのまま上部に描画。
+  canvas.drawImage(base, Offset.zero, Paint());
+
+  // キャプション帯（半透明の濃い背景）。
+  final bandTop = base.height.toDouble();
+  canvas.drawRect(
+    Rect.fromLTWH(0, bandTop, width.toDouble(), bandHeight),
+    Paint()..color = const Color(0xE6101418),
+  );
+
+  // 行を順に描画。
+  double y = bandTop + verticalPadding;
+  for (final tp in painters) {
+    tp.paint(canvas, Offset(horizontalPadding, y));
+    y += tp.height + lineGap;
+  }
+
+  final picture = recorder.endRecording();
+  try {
+    return await picture.toImage(width, totalHeight);
+  } finally {
+    picture.dispose();
+  }
+}
+
+/// PNG バイト列をダウンロード or ドキュメントディレクトリへ書き出し、フルパスを返す。
+///
+/// 規律3: I/O はこの関数だけに閉じ込める。デスクトップでは
+/// [getDownloadsDirectory]、取得できない環境では
+/// [getApplicationDocumentsDirectory] にフォールバックする。
+Future<String> savePng(Uint8List bytes, String filename) async {
+  final dir = (await getDownloadsDirectory()) ??
+      (await getApplicationDocumentsDirectory());
+  final file = File('${dir.path}${Platform.pathSeparator}$filename');
+  await file.writeAsBytes(bytes, flush: true);
+  return file.path;
+}
+
+/// キャプション 1 行の文言とスタイル種別。
+class _CaptionLine {
+  const _CaptionLine(this.text, this.style);
+
+  final String text;
+  final _Style style;
+
+  TextPainter buildPainter(double maxWidth) {
+    final tp = TextPainter(
+      text: TextSpan(text: text, style: style.textStyle),
+      textDirection: TextDirection.ltr,
+      maxLines: style == _Style.note ? 2 : 1,
+      ellipsis: '…',
+    )..layout(maxWidth: maxWidth);
+    return tp;
+  }
+}
+
+/// 焼き込みテキストのスタイル種別。色は帯（暗背景）に対して読みやすい明色に固定。
+enum _Style {
+  title,
+  body,
+  note,
+  meta;
+
+  TextStyle get textStyle {
+    switch (this) {
+      case _Style.title:
+        return const TextStyle(
+          color: Color(0xFFFFFFFF),
+          fontSize: 18,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+        );
+      case _Style.body:
+        return const TextStyle(
+          color: Color(0xFFE6E6E6),
+          fontSize: 14,
+          height: 1.2,
+        );
+      case _Style.note:
+        return const TextStyle(
+          color: Color(0xFFFFD27F),
+          fontSize: 13,
+          fontStyle: FontStyle.italic,
+          height: 1.25,
+        );
+      case _Style.meta:
+        return const TextStyle(
+          color: Color(0xFFB8C0C8),
+          fontSize: 12,
+          height: 1.2,
+        );
+    }
+  }
+}

--- a/lib/ui/widgets/before_after_view.dart
+++ b/lib/ui/widgets/before_after_view.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';

--- a/lib/ui/widgets/before_after_view.dart
+++ b/lib/ui/widgets/before_after_view.dart
@@ -1,12 +1,13 @@
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../l10n/l10n_extensions.dart';
 import '../../models/disability_type.dart';
 import '../../rendering/shader_filter.dart';
+import '../../services/export_service.dart';
 
 /// Side-by-side "before / after" preview for a colour-vision filter.
 ///
@@ -149,6 +150,7 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
   ui.Image? _before;
   ui.Image? _after;
   bool _loading = true;
+  bool _exporting = false;
 
   @override
   void initState() {
@@ -193,6 +195,63 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
     super.dispose();
   }
 
+  /// Exports the current "after" image as a PNG with burned-in metadata (#43).
+  ///
+  /// i18n は **UI 側でここで解決** し、`ExportCaption`（解決済み文字列）として
+  /// pure な [composeExportImage] に渡す（規律2）。保存後はフルパスをテキストとして
+  /// クリップボードへコピーし、SnackBar で結果を知らせる。画像そのものの
+  /// クリップボード書き込みはプラグインを要し環境変更になるため非スコープ。
+  Future<void> _export(AppLocalizations l10n) async {
+    final base = _after;
+    if (base == null || _exporting) return;
+    setState(() => _exporting = true);
+
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final strengthPercent = (widget.intensity.clamp(0.0, 1.0) * 100).round();
+      final date = isoDate(DateTime.now());
+      // 色覚特性は urgency=none のため受診喚起は出さない（緊急性のある症状ではない）。
+      final caption = ExportCaption(
+        symptomLabel: widget.filterType == ColorVisionType.none
+            ? l10n.previewPaneOriginal
+            : colorVisionTypeName(l10n, widget.filterType),
+        strengthLabel: l10n.strengthLabel(strengthPercent),
+        isoDate: date,
+      );
+
+      final composed = await composeExportImage(base, caption);
+      Uint8List? bytes;
+      try {
+        bytes = await encodeImagePng(composed);
+      } finally {
+        composed.dispose();
+      }
+      if (bytes == null) {
+        throw StateError('PNG encoding returned no bytes');
+      }
+
+      final filename = exportFilename(
+        symptomId: widget.filterType.id,
+        strengthPercent: strengthPercent,
+        isoDate: date,
+      );
+      final path = await savePng(bytes, filename);
+      await Clipboard.setData(ClipboardData(text: path));
+
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.exportSuccess(path))),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.exportFailure)),
+      );
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -226,6 +285,17 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
           label: widget.filterType == ColorVisionType.none
               ? l10n.previewPaneOriginal
               : colorVisionTypeName(l10n, widget.filterType),
+          // Export is only meaningful when a real "after" image exists.
+          // Coming-soon filters (null _after) get no button.
+          trailing: _after != null
+              ? IconButton(
+                  icon: const Icon(Icons.download_outlined),
+                  iconSize: 20,
+                  visualDensity: VisualDensity.compact,
+                  tooltip: l10n.exportButtonTooltip,
+                  onPressed: _exporting ? null : () => _export(l10n),
+                )
+              : null,
           child: _after != null
               ? _ImageView(image: _after)
               : _ComingSoonPlaceholder(
@@ -255,10 +325,13 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
 }
 
 class _Pane extends StatelessWidget {
-  const _Pane({required this.label, required this.child});
+  const _Pane({required this.label, required this.child, this.trailing});
 
   final String label;
   final Widget child;
+
+  /// Optional action shown to the right of the label (e.g. the export button).
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -267,7 +340,21 @@ class _Pane extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(label, style: theme.textTheme.labelLarge),
+        SizedBox(
+          height: 32,
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.labelLarge,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (trailing != null) trailing!,
+            ],
+          ),
+        ),
         const SizedBox(height: 6),
         AspectRatio(
           aspectRatio: 1,

--- a/lib/ui/widgets/before_after_view.dart
+++ b/lib/ui/widgets/before_after_view.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -211,6 +212,9 @@ class _BeforeAfterViewState extends State<BeforeAfterView> {
       final strengthPercent = (widget.intensity.clamp(0.0, 1.0) * 100).round();
       final date = isoDate(DateTime.now());
       // 色覚特性は urgency=none のため受診喚起は出さない（緊急性のある症状ではない）。
+      // 色覚 7 型（このウィジェットが扱う範囲）は urgency=none なので受診喚起は焼かない。
+      // sensus advanced フィルタ（緑内障等）の live export に拡張する際は、ここで
+      // `consultMessageForUrgency(...)` を解決して `urgencyMessage` に渡せる（拡張ポイント）。
       final caption = ExportCaption(
         symptomLabel: widget.filterType == ColorVisionType.none
             ? l10n.previewPaneOriginal

--- a/test/export_service_test.dart
+++ b/test/export_service_test.dart
@@ -1,0 +1,148 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_experience/services/export_service.dart';
+import 'package:universal_experience/ui/widgets/before_after_view.dart';
+
+/// export_service の pure 中核（ISO 日付・ファイル名・メタ焼き込み PNG 合成）の
+/// テスト (#43)。I/O（savePng）は path_provider の実プラットフォームを要するため
+/// headless では検証せず、Issue の検証手段「PNG バイト非空・メタ一致」を満たす
+/// 純粋関数（isoDate / exportFilename / composeExportImage）を直接検証する。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('isoDate', () {
+    test('YYYY-MM-DD（ゼロ埋め・スラッシュ禁止）で整形する', () {
+      expect(isoDate(DateTime(2026, 6, 23)), '2026-06-23');
+    });
+
+    test('月日をゼロ埋めする', () {
+      expect(isoDate(DateTime(2026, 1, 5)), '2026-01-05');
+    });
+
+    test('スラッシュを含まない（ISO 固定）', () {
+      final s = isoDate(DateTime(2026, 12, 31));
+      expect(s.contains('/'), isFalse);
+      expect(s, '2026-12-31');
+    });
+  });
+
+  group('exportFilename', () {
+    test('メタ（symptomId・strengthPercent・isoDate）を含み .png 拡張子を持つ', () {
+      final name = exportFilename(
+        symptomId: 'protanopia',
+        strengthPercent: 100,
+        isoDate: '2026-06-23',
+      );
+      expect(name, contains('protanopia'));
+      expect(name, contains('100pct'));
+      expect(name, contains('2026-06-23'));
+      expect(name, endsWith('.png'));
+    });
+
+    test('決定論的（同じ入力なら同じ出力）', () {
+      String make() => exportFilename(
+            symptomId: 'deuteranopia',
+            strengthPercent: 60,
+            isoDate: '2026-01-05',
+          );
+      expect(make(), make());
+      expect(make(), 'ue-deuteranopia-60pct-2026-01-05.png');
+    });
+
+    test('symptomId が none でも妥当なファイル名になる', () {
+      final name = exportFilename(
+        symptomId: 'none',
+        strengthPercent: 0,
+        isoDate: '2026-06-23',
+      );
+      expect(name, 'ue-none-0pct-2026-06-23.png');
+    });
+
+    test('ファイル名に使えない文字を含まない', () {
+      final name = exportFilename(
+        symptomId: 'weird/id:with*bad?chars',
+        strengthPercent: 50,
+        isoDate: '2026-06-23',
+      );
+      for (final ch in <String>['/', '\\', ':', '*', '?', '"', '<', '>', '|']) {
+        expect(name.contains(ch), isFalse, reason: 'must not contain "$ch"');
+      }
+      expect(name, endsWith('.png'));
+    });
+  });
+
+  group('composeExportImage', () {
+    /// テスト用の小さなダミー [ui.Image] を生成する。
+    Future<ui.Image> makeBase(int w, int h) async {
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawRect(
+        ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+        ui.Paint()..color = const ui.Color(0xFF3366CC),
+      );
+      final picture = recorder.endRecording();
+      try {
+        return await picture.toImage(w, h);
+      } finally {
+        picture.dispose();
+      }
+    }
+
+    test('帯ぶん base より高い画像を返し、幅は維持する', () async {
+      final base = await makeBase(64, 48);
+      const caption = ExportCaption(
+        symptomLabel: 'Protanopia',
+        strengthLabel: 'Strength: 100%',
+        isoDate: '2026-06-23',
+      );
+      final composed = await composeExportImage(base, caption);
+      addTearDown(() {
+        base.dispose();
+        composed.dispose();
+      });
+
+      expect(composed.width, base.width);
+      expect(composed.height, greaterThan(base.height));
+    });
+
+    test('合成画像を PNG 化すると非空バイトが得られる', () async {
+      final base = await makeBase(64, 48);
+      const caption = ExportCaption(
+        symptomLabel: 'Tritanopia',
+        strengthLabel: 'Strength: 60%',
+        isoDate: '2026-01-05',
+      );
+      final composed = await composeExportImage(base, caption);
+      final png = await encodeImagePng(composed);
+      addTearDown(() {
+        base.dispose();
+        composed.dispose();
+      });
+
+      expect(png, isNotNull);
+      expect(png!.isNotEmpty, isTrue);
+    });
+
+    test('受診喚起あり（urgencyMessage 非 null）でも合成・PNG 化できる', () async {
+      final base = await makeBase(80, 60);
+      const caption = ExportCaption(
+        symptomLabel: 'Glaucoma',
+        strengthLabel: 'Strength: 80%',
+        urgencyMessage: 'Sudden changes in vision can need prompt care.',
+        isoDate: '2026-06-23',
+      );
+      final composed = await composeExportImage(base, caption);
+      final png = await encodeImagePng(composed);
+      addTearDown(() {
+        base.dispose();
+        composed.dispose();
+      });
+
+      // urgency 行ぶん、urgency なしより高くなる（行が増える）。
+      expect(composed.height, greaterThan(base.height));
+      expect(png, isNotNull);
+      expect(png!.isNotEmpty, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 関連 Issue
Refs #43（headless 中核は完了。**ファイル保存・ボタンの実機サインオフ後に close 判断**）

## 概要（VIP-Sim 監査 #6 由来の差別化）
フィルタ適用後（before/after の after）画像を **症状名・強度・受診喚起・日付(ISO) を焼き込んだ PNG にエクスポート**。設計者へ「この症状ではこう見える」を共有する導線（VIP-Sim に無い ue の差別化）。

## 変更
- **`lib/services/export_service.dart`**（pure 中核 + I/O 隔離）:
  - `isoDate(DateTime)` → `YYYY-MM-DD`（ゼロ埋め・スラッシュ禁止・ISO 固定）
  - `exportFilename({symptomId, strengthPercent, isoDate})` → `ue-{id}-{pct}pct-{date}.png`（不正文字 sanitize・決定論的）
  - `ExportCaption`（**解決済み i18n 文字列のみ**受ける＝規律2）
  - `composeExportImage(base, caption)` → base 下部に半透明帯＋`TextPainter` で焼き込み・**pure**（I/O なし＝規律3）
  - `savePng(bytes, filename)` → **I/O はここだけ**に隔離（path_provider downloads→documents fallback + dart:io）
- **`before_after_view.dart`**: after 実描画時（protanopia/protanomaly/none）のみエクスポート `IconButton`。タップで i18n を UI 解決→compose→`encodeImagePng`(既存)→savePng→`Clipboard.setData`(パス)→SnackBar。例外は握って失敗 SnackBar。
- **i18n（en/ja parity 142=142）**: `exportButtonTooltip`/`exportSuccess{path}`/`exportFailure`。強度ラベルは既存 `strengthLabel` 流用。

## 非スコープ
- 動画録画 / ライブ画面キャプチャ(#1/#5)。
- **画像そのものをクリップボードへ**（プラグイン＝環境変更要）→ パス文字列のテキストコピーに留めた。

## テスト（headless 中核＝Issue の検証手段「PNG バイト非空・メタ一致」）
- `test/export_service_test.dart`（10件）: isoDate（ゼロ埋め・スラッシュ非含有）/ exportFilename（メタ含有・決定論的・`.png`・不正文字なし）/ composeExportImage（帯ぶん高い・幅維持・`encodeImagePng` 非空・urgency 有りでも生成可）。
- `flutter analyze` No issues・`flutter test` **198 passed**（188+10）・ARB parity・`dart format` 済み。Rust 不変。
- **未検証（実機）**: `savePng` の実ファイル書き出し（path_provider は実機要）・ボタン押下の見た目。→ #43 は実機サインオフ後に close。